### PR TITLE
Enhanced types for InstalledApp to include onPress callback for app icons.

### DIFF
--- a/packages/devtools-floating-menu/src/floatingMenu/dial/DialDevTools.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/dial/DialDevTools.tsx
@@ -129,7 +129,7 @@ export const DialDevTools: FC<DialDevToolsProps> = ({
     name: `empty-${slotIndex}`,
     icon: null,
     color: "transparent",
-    onPress: () => {},
+    onPress: () => { },
   });
 
   const enabledIcons: IconType[] = [];
@@ -150,6 +150,7 @@ export const DialDevTools: FC<DialDevToolsProps> = ({
           : app.icon,
       color: app.color ?? gameUIColors.primary,
       onPress: () => {
+        app?.onPress?.();
         open({
           id: app.id,
           title: app.name,
@@ -167,8 +168,7 @@ export const DialDevTools: FC<DialDevToolsProps> = ({
     const totalEnabled = dialApps.filter((app) => isDialEnabled(app.id)).length;
     if (totalEnabled > MAX_DIAL_SLOTS) {
       console.warn(
-        `[DialDevTools] Only ${MAX_DIAL_SLOTS} dial tools can be shown at once. ${
-          totalEnabled - MAX_DIAL_SLOTS
+        `[DialDevTools] Only ${MAX_DIAL_SLOTS} dial tools can be shown at once. ${totalEnabled - MAX_DIAL_SLOTS
         } tool(s) were hidden. Adjust dial defaults to avoid this warning.`
       );
     }

--- a/packages/devtools-floating-menu/src/floatingMenu/types.ts
+++ b/packages/devtools-floating-menu/src/floatingMenu/types.ts
@@ -51,4 +51,6 @@ export interface InstalledApp {
   launchMode?: "self-modal" | "host-modal" | "inline";
   /** Prevent more than one instance of this app at a time. */
   singleton?: boolean;
+  /** Optional callback invoked when the app icon is pressed. */
+  onPress?: () => void;
 }


### PR DESCRIPTION
feat(dev-tools): add optional onPress handler to dial components/icons

Added support for an optional `onPress` property on dial tool items.
This allows icons that are directly pressable (like logout) to trigger actions
without opening a component modal.

Previously, when a pressable icon (e.g., LOGOUT) was selected,
the component name overlay blocked the actual press event,
preventing the action from firing. Moving the press handling
to the tool-level fixes this behavior.

Example :
`{
  id: 'logout',
  name: 'LOGOUT',
  description: 'Clear authentication state',
  slot: 'both',
  icon: ({ size }) => (
    <MaterialCommunityIcons name="logout" color="cyan" size={size} />
  ),
  onPress: () => useAuthStore.getState().clearAuthState(),
}`