### PR TITLE
feat(core): add enabledByDefault option for InstalledApp tools

### DIFF
--- a/docs/custom-tools.md
+++ b/docs/custom-tools.md
@@ -55,6 +55,9 @@ interface CustomTool {
 
   /** Optional description shown in menu */
   description?: string;
+
+  /** Enable in dial/floating row by default (before user configures preferences) */
+  enabledByDefault?: boolean;
 }
 ```
 
@@ -81,6 +84,37 @@ interface CustomTool {
       component: AnalyticsDebugger,
       icon: "📊",
       description: "Event tracking",
+    },
+  ]}
+/>
+```
+
+## Default-Enabled Tools
+
+By default, all tools start disabled in the dial and floating row until the user
+enables them via the settings modal. Use `enabledByDefault: true` to have a tool
+appear in the dial and floating row immediately, without requiring manual setup.
+
+Once the user has toggled a tool in the settings modal, their preference is
+persisted and always takes precedence over `enabledByDefault`.
+
+```tsx
+<FloatingDevTools
+  environment="local"
+  customTools={[
+    {
+      name: "Auth",
+      component: AuthDebugger,
+      icon: "🔐",
+      description: "View auth state",
+      enabledByDefault: true, // Appears in the dial immediately
+    },
+    {
+      name: "Feature Flags",
+      component: FeatureFlagViewer,
+      icon: "🚩",
+      description: "Toggle features",
+      // Not enabled by default — user must opt in via settings
     },
   ]}
 />

--- a/docs/floating-devtools.md
+++ b/docs/floating-devtools.md
@@ -105,6 +105,31 @@ function App() {
 
 See [Custom Tools](./custom-tools) for more details on building your own debugging tools.
 
+## Default-Enabled Tools
+
+By default, all tools (both built-in and custom) are disabled in the dial and floating row
+until the user enables them via the settings modal. To have a tool appear immediately without
+requiring setup, set `enabledByDefault: true` on the `InstalledApp` config:
+
+```tsx
+<FloatingDevTools
+  environment="qa"
+  customTools={[
+    {
+      name: "Flags",
+      component: FeatureFlagTool,
+      icon: "🚩",
+      enabledByDefault: true, // Visible in dial on first launch
+    },
+  ]}
+/>
+```
+
+User preferences (persisted via AsyncStorage) always take precedence. Once a user
+explicitly toggles a tool in the settings modal, `enabledByDefault` is no longer consulted.
+
+Built-in tool packages can also opt into this by exporting their preset with `enabledByDefault: true`.
+
 ## Draggable Button
 
 The floating button can be dragged anywhere on screen. It remembers its position between sessions, so it stays where your team likes it.

--- a/packages/devtools-floating-menu/package.json
+++ b/packages/devtools-floating-menu/package.json
@@ -1,0 +1,75 @@
+{
+  "name": "@react-buoy/core",
+  "version": "1.5.8",
+  "description": "Floating dev tools launcher and AppHost",
+  "main": "lib/commonjs/index.js",
+  "module": "lib/module/index.js",
+  "types": "lib/typescript/module/index.d.ts",
+  "react-native": "src/index.tsx",
+  "source": "src/index.tsx",
+  "exports": {
+    ".": {
+      "types": "./lib/typescript/module/index.d.ts",
+      "react-native": "./src/index.tsx",
+      "import": "./lib/module/index.js",
+      "require": "./lib/commonjs/index.js",
+      "default": "./lib/commonjs/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "src",
+    "lib"
+  ],
+  "sideEffects": false,
+  "dependencies": {
+    "@react-buoy/shared-ui": "1.5.8"
+  },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
+  "react-native-builder-bob": {
+    "source": "src",
+    "output": "lib",
+    "targets": [
+      [
+        "commonjs",
+        {
+          "esm": true
+        }
+      ],
+      [
+        "module",
+        {
+          "esm": true
+        }
+      ],
+      "typescript"
+    ]
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.0",
+    "@types/react-native": "^0.73.0",
+    "typescript": "~5.8.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/LovesWorking/react-native-buoy.git",
+    "directory": "packages/devtools-floating-menu"
+  },
+  "bugs": {
+    "url": "https://github.com/LovesWorking/react-native-buoy/issues"
+  },
+  "homepage": "https://github.com/LovesWorking/react-native-buoy/tree/main/packages/devtools-floating-menu#readme",
+  "publishConfig": {
+    "access": "public",
+    "tag": "latest"
+  },
+  "scripts": {
+    "build": "bob build",
+    "typecheck": "tsc --noEmit",
+    "clean": "rimraf lib",
+    "test": "pnpm run typecheck"
+  }
+}

--- a/packages/devtools-floating-menu/src/floatingMenu/AppHost.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/AppHost.tsx
@@ -1,0 +1,273 @@
+import { safeGetItem, safeSetItem } from "@react-buoy/shared-ui";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+  useRef,
+  ReactNode,
+} from "react";
+import { BackHandler, Modal, StyleSheet, View } from "react-native";
+import {
+  AppInstance,
+  LaunchMode,
+  OpenDefinition,
+  resolveOpenAppsState,
+} from "./AppHostLogic";
+
+type AppHostContextValue = {
+  openApps: AppInstance[];
+  isAnyOpen: boolean;
+  open: (def: Omit<AppInstance, "instanceId">) => string;
+  close: (instanceId?: string) => void;
+  closeAll: () => void;
+  registerApps?: (apps: any[]) => void;
+};
+
+const AppHostContext = createContext<AppHostContextValue | null>(null);
+
+const STORAGE_KEY_OPEN_APPS = "@react_buoy_open_apps";
+const PERSISTENCE_DELAY = 500;
+
+/**
+ * Provides the floating dev tools application host. Tracks open tool instances, restores
+ * persisted state, and exposes imperative helpers used by `FloatingMenu` and friends.
+ */
+export const AppHostProvider = ({ children }: { children: ReactNode }) => {
+  const [openApps, setOpenApps] = useState<AppInstance[]>([]);
+  const [isRestored, setIsRestored] = useState(false);
+  const persistenceTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null
+  );
+  const installedAppsRef = useRef<any[]>([]);
+  const pendingRestoreRef = useRef<string[] | null>(null);
+
+  const open: AppHostContextValue["open"] = useCallback((def) => {
+    let resolvedId = "";
+
+    setOpenApps((current) => {
+      const { apps, instanceId } = resolveOpenAppsState(
+        current,
+        def,
+        () => `${def.id}-${Date.now()}-${Math.random().toString(36).slice(2)}`
+      );
+      resolvedId = instanceId;
+      return apps;
+    });
+
+    return resolvedId;
+  }, []);
+
+  const tryRestorePending = useCallback(() => {
+    if (isRestored) return;
+    if (!installedAppsRef.current.length) return;
+
+    const pendingIds = pendingRestoreRef.current;
+    if (!pendingIds || pendingIds.length === 0) {
+      setIsRestored(true);
+      return;
+    }
+
+    pendingRestoreRef.current = null;
+
+    pendingIds.forEach((appId) => {
+      const appDef = installedAppsRef.current.find(
+        (app: any) => app.id === appId
+      );
+      if (appDef) {
+        open({
+          id: appDef.id,
+          title: appDef.name,
+          component: appDef.component,
+          props: appDef.props,
+          launchMode: appDef.launchMode || "self-modal",
+          singleton: appDef.singleton,
+        });
+      }
+    });
+
+    setIsRestored(true);
+  }, [isRestored, open]);
+
+  // Restore open apps on mount
+  useEffect(() => {
+    const restoreOpenApps = async () => {
+      try {
+        const saved = await safeGetItem(STORAGE_KEY_OPEN_APPS);
+        if (saved) {
+          const savedApps = JSON.parse(saved) as string[];
+          if (savedApps.length) {
+            pendingRestoreRef.current = savedApps;
+            tryRestorePending();
+            return;
+          }
+        }
+      } catch (error) {
+        // Failed to restore open apps - continue with fresh state
+      }
+
+      setIsRestored(true);
+    };
+
+    restoreOpenApps();
+  }, [tryRestorePending]);
+
+  // Save open apps with debounce
+  useEffect(() => {
+    if (!isRestored) return;
+
+    // Clear existing timeout
+    if (persistenceTimeoutRef.current) {
+      clearTimeout(persistenceTimeoutRef.current);
+    }
+
+    // Set new timeout to save
+    persistenceTimeoutRef.current = setTimeout(() => {
+      const appIds = openApps.map((app) => app.id);
+      safeSetItem(STORAGE_KEY_OPEN_APPS, JSON.stringify(appIds));
+    }, PERSISTENCE_DELAY);
+
+    return () => {
+      if (persistenceTimeoutRef.current) {
+        clearTimeout(persistenceTimeoutRef.current);
+      }
+    };
+  }, [openApps, isRestored]);
+
+  // Store reference to installed apps for restoration
+  const registerApps = useCallback(
+    (apps: any[]) => {
+      installedAppsRef.current = apps;
+      tryRestorePending();
+    },
+    [tryRestorePending]
+  );
+
+  const close: AppHostContextValue["close"] = useCallback((instanceId) => {
+    setOpenApps((s) => {
+      if (!s.length) return s;
+      if (!instanceId) return s.slice(0, -1);
+      return s.filter((a) => a.instanceId !== instanceId);
+    });
+  }, []);
+
+  const closeAll = useCallback(() => setOpenApps([]), []);
+
+  React.useEffect(() => {
+    if (openApps.length === 0) return;
+
+    const handler = () => {
+      close();
+      return true;
+    };
+    const sub = BackHandler.addEventListener("hardwareBackPress", handler);
+    return () => sub.remove();
+  }, [openApps.length, close]);
+
+  const value = useMemo<AppHostContextValue>(
+    () => ({
+      openApps,
+      // Only count non-toggle-only tools as "open" (toggle-only tools don't show modals)
+      isAnyOpen:
+        openApps.filter((app) => app.launchMode !== "toggle-only").length > 0,
+      open,
+      close,
+      closeAll,
+      registerApps,
+    }),
+    [openApps, open, close, closeAll, registerApps]
+  );
+
+  return (
+    <AppHostContext.Provider value={value}>{children}</AppHostContext.Provider>
+  );
+};
+
+/**
+ * Accessor hook for the dev tools app host. Components can open/close tools or inspect
+ * the active stack. Falls back to a no-op implementation when rendered outside the provider.
+ */
+export const useAppHost = () => {
+  const ctx = useContext(AppHostContext);
+  // Return a default value if not in provider (for backwards compatibility)
+  if (!ctx) {
+    return {
+      openApps: [],
+      isAnyOpen: false,
+      open: () => "",
+      close: () => {},
+      closeAll: () => {},
+    };
+  }
+  return ctx;
+};
+
+/**
+ * Renders the active dev tool surface on top of the host application. Handles all supported
+ * launch modes (self-managed modals, host-wrapped modal, or inline overlays).
+ */
+export const AppOverlay = () => {
+  const { openApps, close } = useAppHost();
+  if (openApps.length === 0) return null;
+
+  const top = openApps[openApps.length - 1];
+
+  // Skip rendering for toggle-only tools (they don't need a modal/overlay)
+  if (top.launchMode === "toggle-only") {
+    return null;
+  }
+
+  const Comp = top.component as any;
+
+  if (top.launchMode === "self-modal") {
+    return (
+      <Comp
+        {...(top.props ?? {})}
+        visible={true}
+        onClose={() => close(top.instanceId)}
+        onRequestClose={() => close(top.instanceId)}
+      />
+    );
+  }
+
+  if (top.launchMode === "inline") {
+    return (
+      <View pointerEvents="box-none" style={StyleSheet.absoluteFill}>
+        <Comp {...(top.props ?? {})} onClose={() => close(top.instanceId)} />
+      </View>
+    );
+  }
+
+  return (
+    <Modal
+      visible
+      transparent
+      animationType="slide"
+      onRequestClose={() => close(top.instanceId)}
+    >
+      <View style={styles.backdrop}>
+        <View style={styles.card}>
+          <Comp {...(top.props ?? {})} onClose={() => close(top.instanceId)} />
+        </View>
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: "rgba(0,0,0,0.28)",
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  card: {
+    maxHeight: "90%",
+    width: "94%",
+    borderRadius: 12,
+    backgroundColor: "white",
+    overflow: "hidden",
+  },
+});

--- a/packages/devtools-floating-menu/src/floatingMenu/AppHostLogic.ts
+++ b/packages/devtools-floating-menu/src/floatingMenu/AppHostLogic.ts
@@ -1,0 +1,50 @@
+import type { ComponentType } from "react";
+
+export type LaunchMode = "self-modal" | "host-modal" | "inline" | "toggle-only";
+
+export type AppInstance = {
+  instanceId: string;
+  id: string;
+  title?: string;
+  component: ComponentType<any>;
+  props?: Record<string, unknown>;
+  launchMode: LaunchMode;
+  singleton?: boolean;
+};
+
+export type OpenDefinition = Omit<AppInstance, "instanceId">;
+
+/**
+ * Computes the new list of open tool instances when a user launches a dev app. Singleton
+ * tools reuse their existing instance while non-singletons create a new entry using the
+ * provided `generateId` helper.
+ *
+ * @param current - Current stack of open app instances.
+ * @param def - Descriptor of the tool to launch (without runtime instance id).
+ * @param generateId - Callback used to generate a unique instance identifier.
+ * @returns Updated instance list alongside the resolved instance id.
+ */
+export const resolveOpenAppsState = (
+  current: AppInstance[],
+  def: OpenDefinition,
+  generateId: () => string
+): { apps: AppInstance[]; instanceId: string } => {
+  if (def.singleton) {
+    const existing = current.find((app) => app.id === def.id);
+    if (existing) {
+      return {
+        instanceId: existing.instanceId,
+        apps: [
+          ...current.filter((app) => app.instanceId !== existing.instanceId),
+          existing,
+        ],
+      };
+    }
+  }
+
+  const instanceId = generateId();
+  return {
+    instanceId,
+    apps: [...current, { ...def, instanceId }],
+  };
+};

--- a/packages/devtools-floating-menu/src/floatingMenu/DevToolsSettingsModal.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/DevToolsSettingsModal.tsx
@@ -1,0 +1,765 @@
+import { useState, useEffect, useCallback, useMemo, FC } from "react";
+import {
+  View,
+  Text,
+  StyleSheet,
+  ScrollView,
+  TouchableOpacity,
+  Dimensions,
+} from "react-native";
+import { settingsBus } from "./settingsBus";
+import {
+  ReactQueryIcon,
+  EnvLaptopIcon,
+  SentryBugIcon,
+  StorageStackIcon,
+  WifiCircuitIcon,
+  RouteMapIcon,
+  Globe,
+  Info,
+  ChevronRightIcon,
+  safeGetItem,
+  safeSetItem,
+} from "@react-buoy/shared-ui";
+import { JsModal, type ModalMode, devToolsStorageKeys } from "@react-buoy/shared-ui";
+import { gameUIColors } from "@react-buoy/shared-ui";
+import { useSafeAreaInsets } from "@react-buoy/shared-ui";
+import { ModalHeader } from "@react-buoy/shared-ui";
+import { TabSelector } from "@react-buoy/shared-ui";
+
+const STORAGE_KEY = "@react_buoy_dev_tools_settings";
+const MAX_DIAL_SLOTS = 6;
+
+const enforceDialLimit = (
+  dialTools: Record<string, boolean>
+): Record<string, boolean> => {
+  let remaining = MAX_DIAL_SLOTS;
+  const limited: Record<string, boolean> = {};
+
+  for (const [id, enabled] of Object.entries(dialTools)) {
+    if (enabled && remaining > 0) {
+      limited[id] = true;
+      remaining -= 1;
+    } else {
+      limited[id] = false;
+    }
+  }
+
+  return limited;
+};
+
+const sanitizeFloating = (
+  floating: DevToolsSettings["floatingTools"],
+  allowedKeys?: string[]
+) => {
+  const { userStatus, environment, ...rest } = floating as Record<
+    string,
+    boolean
+  > & {
+    userStatus?: boolean;
+    environment?: boolean;
+  };
+
+  const filteredEntries = allowedKeys
+    ? Object.entries(rest).filter(([key]) => allowedKeys.includes(key))
+    : Object.entries(rest);
+
+  return {
+    ...Object.fromEntries(filteredEntries),
+    environment: environment ?? false,
+  };
+};
+
+const mergeWithDefaults = (
+  defaults: DevToolsSettings,
+  stored?: Partial<DevToolsSettings> | null,
+  options?: {
+    allowedDialKeys?: string[];
+    allowedFloatingKeys?: string[];
+  }
+): DevToolsSettings => {
+  if (!stored) return defaults;
+
+  const combinedDial = {
+    ...defaults.dialTools,
+    ...(stored.dialTools ?? {}),
+  };
+  const dialEntries = options?.allowedDialKeys
+    ? Object.entries(combinedDial).filter(([key]) =>
+        options.allowedDialKeys?.includes(key)
+      )
+    : Object.entries(combinedDial);
+  const mergedDial = enforceDialLimit(Object.fromEntries(dialEntries));
+
+  return {
+    dialTools: mergedDial,
+    floatingTools: sanitizeFloating(
+      {
+        ...defaults.floatingTools,
+        ...(stored.floatingTools ?? {}),
+      },
+      options?.allowedFloatingKeys
+    ),
+  };
+};
+
+/**
+ * Serialized preferences that power the floating dev tools UI. Values persist across sessions
+ * via AsyncStorage so teams can tailor which tools appear in the dial or floating row.
+ */
+export interface DevToolsSettings {
+  /** Map of dial tool ids to enabled state (max slots enforced elsewhere). */
+  dialTools: Record<string, boolean>;
+  /** Map of floating tool ids to enabled state plus the environment indicator toggle. */
+  floatingTools: Record<string, boolean> & {
+    environment: boolean; // Special setting for environment indicator
+  };
+}
+
+interface DevToolsSettingsModalProps {
+  visible: boolean;
+  onClose: () => void;
+  onSettingsChange?: (settings: DevToolsSettings) => void;
+  initialSettings?: DevToolsSettings;
+  availableApps?: {
+    id: string;
+    name: string;
+    description?: string;
+    slot?: "dial" | "row" | "both";
+    enabledByDefault?: boolean;
+  }[];
+}
+
+// Generate default settings based on available apps
+const generateDefaultSettings = (
+  availableApps: {
+    id: string;
+    name: string;
+    description?: string;
+    slot?: "dial" | "row" | "both";
+    enabledByDefault?: boolean;
+  }[] = []
+): DevToolsSettings => {
+  const dialDefaults: Record<string, boolean> = {};
+  const floatingDefaults: Record<string, boolean> = {};
+
+  for (const app of availableApps) {
+    const { id, slot = "both", enabledByDefault = false } = app;
+
+    if (slot === "dial" || slot === "both") {
+      dialDefaults[id] = enabledByDefault;
+    }
+
+    if (slot === "row" || slot === "both") {
+      floatingDefaults[id] = enabledByDefault;
+    }
+  }
+
+  return {
+    dialTools: enforceDialLimit(dialDefaults),
+    floatingTools: {
+      ...floatingDefaults,
+      environment: false,
+    },
+  };
+};
+
+/**
+ * Configurable modal surface that lets engineers pick which dev tools appear in the dial and
+ * floating row. Persists preferences and enforces slot limits for a consistent UX.
+ */
+export const DevToolsSettingsModal: FC<DevToolsSettingsModalProps> = ({
+  visible,
+  onClose,
+  onSettingsChange,
+  initialSettings,
+  availableApps = [],
+}) => {
+  const defaultSettings = useMemo(
+    () => generateDefaultSettings(availableApps),
+    [availableApps]
+  );
+  const allowedDialKeys = useMemo(
+    () => Object.keys(defaultSettings.dialTools),
+    [defaultSettings]
+  );
+  const allowedFloatingKeys = useMemo(
+    () =>
+      Object.keys(defaultSettings.floatingTools).filter(
+        (key) => key !== "environment"
+      ),
+    [defaultSettings]
+  );
+  const [settings, setSettings] = useState<DevToolsSettings>(
+    initialSettings || defaultSettings
+  );
+  const [activeTab, setActiveTab] = useState<"dial" | "floating">("dial");
+  const insets = useSafeAreaInsets();
+  const screenHeight = Dimensions.get("window").height;
+  const screenWidth = Dimensions.get("window").width;
+  const modalHeight = Math.floor(screenHeight * 0.33); // 1/3 of screen height
+  const modalWidth = Math.min(screenWidth - 32, 400); // Modal width with padding
+
+  const loadSettings = useCallback(async () => {
+    try {
+      const savedSettings = await safeGetItem(STORAGE_KEY);
+      if (savedSettings) {
+        const parsed = JSON.parse(savedSettings) as DevToolsSettings;
+        const merged = mergeWithDefaults(defaultSettings, parsed, {
+          allowedDialKeys,
+          allowedFloatingKeys,
+        });
+        setSettings(merged);
+        return;
+      }
+      setSettings(defaultSettings);
+    } catch (error) {
+      console.error("Failed to load dev tools settings:", error);
+      setSettings(defaultSettings);
+    }
+  }, [defaultSettings, allowedDialKeys, allowedFloatingKeys]);
+
+  useEffect(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  const saveSettings = async (newSettings: DevToolsSettings) => {
+    try {
+      const limitedSettings: DevToolsSettings = {
+        ...newSettings,
+        dialTools: enforceDialLimit(newSettings.dialTools),
+      };
+
+      await safeSetItem(STORAGE_KEY, JSON.stringify(limitedSettings));
+      setSettings(limitedSettings);
+      onSettingsChange?.(limitedSettings);
+      // Notify listeners (e.g., floating bubble) to refresh immediately
+      settingsBus.emit(limitedSettings);
+    } catch (error) {
+      console.error("Failed to save dev tools settings:", error);
+    }
+  };
+
+  const toggleDialTool = (tool: keyof DevToolsSettings["dialTools"]) => {
+    const currentEnabled = Object.values(settings.dialTools).filter(
+      (v) => v
+    ).length;
+    const isCurrentlyEnabled = settings.dialTools[tool];
+
+    // If trying to enable and already at 6, don't allow
+    if (!isCurrentlyEnabled && currentEnabled >= MAX_DIAL_SLOTS) {
+      return; // Could also show a toast/alert here
+    }
+
+    const newSettings = {
+      ...settings,
+      dialTools: {
+        ...settings.dialTools,
+        [tool]: !settings.dialTools[tool],
+      },
+    };
+    saveSettings(newSettings);
+  };
+
+  const toggleFloatingTool = (
+    tool: keyof DevToolsSettings["floatingTools"]
+  ) => {
+    const newSettings = {
+      ...settings,
+      floatingTools: {
+        ...settings.floatingTools,
+        [tool]: !settings.floatingTools[tool],
+      },
+    };
+    saveSettings(newSettings);
+  };
+
+  // Modal is fixed to bottom sheet mode
+  const handleModeChange = useCallback((_mode: ModalMode) => {
+    // Mode changes handled by JsModal
+  }, []);
+
+  const getToolColor = (tool: string): string => {
+    const colors: Record<string, string> = {
+      query: gameUIColors.query,
+      env: gameUIColors.env,
+      sentry: gameUIColors.debug,
+      storage: gameUIColors.storage,
+      wifi: gameUIColors.network,
+      network: gameUIColors.network,
+      environment: gameUIColors.env,
+    };
+    return colors[tool] || gameUIColors.info;
+  };
+
+  const getToolDescription = (tool: string): string => {
+    // Get description from availableApps
+    const app = availableApps.find((a) => a.id === tool);
+    if (app?.description) {
+      return app.description;
+    }
+    if (tool === "environment") {
+      return "Environment badge.";
+    }
+    return "";
+  };
+
+  const getToolLabel = (tool: string): string => {
+    if (tool === "environment") {
+      return "ENV BADGE";
+    }
+    const app = availableApps.find((a) => a.id === tool);
+    return app?.name ?? tool.toUpperCase().replace(/_/g, " ");
+  };
+
+  // Glass + Neon Edge card renderer (variant 1 from showcase)
+  const renderToolCard = (
+    keyName: string,
+    value: boolean,
+    disabled: boolean,
+    onToggle: () => void
+  ) => {
+    const color = getToolColor(keyName);
+    const getToolIcon = (tool: string) => {
+      switch (tool) {
+        case "query":
+          return (
+            <ReactQueryIcon
+              size={16}
+              color={color}
+              glowColor={color}
+              noBackground
+            />
+          );
+        case "env":
+          return (
+            <EnvLaptopIcon
+              size={16}
+              color={color}
+              glowColor={color}
+              noBackground
+            />
+          );
+        case "sentry":
+          return (
+            <SentryBugIcon
+              size={16}
+              color={color}
+              glowColor={color}
+              noBackground
+            />
+          );
+        case "storage":
+          return (
+            <StorageStackIcon
+              size={16}
+              color={color}
+              glowColor={color}
+              noBackground
+            />
+          );
+        case "wifi":
+        case "query-wifi-toggle": // Support both IDs for wifi toggle
+          return (
+            <WifiCircuitIcon
+              size={16}
+              color={color}
+              glowColor={color}
+              strength={4}
+              noBackground
+            />
+          );
+        case "route-events":
+          return (
+            <RouteMapIcon
+              size={16}
+              color={color}
+              glowColor={color}
+              noBackground
+            />
+          );
+        case "network":
+          return <Globe size={16} color={color} />;
+        case "environment":
+          return <Info size={16} color={color} />;
+        default:
+          return <Info size={16} color={color} />;
+      }
+    };
+
+    return (
+      <TouchableOpacity
+        key={keyName}
+        activeOpacity={disabled ? 1 : 0.85}
+        onPress={() => !disabled && onToggle()}
+        style={{ marginBottom: 10, opacity: disabled ? 0.6 : 1 }}
+      >
+        <View
+          style={[
+            styles.glassCard,
+            {
+              borderColor: `${color}40`,
+              shadowColor: color,
+              shadowOpacity: 0.2,
+              shadowRadius: 6,
+              shadowOffset: { width: 0, height: 0 },
+            },
+          ]}
+        >
+          <View style={styles.glassCardInner}>
+            {/* Icon in colored circle */}
+            <View
+              style={[
+                styles.iconCircle,
+                {
+                  backgroundColor: `${color}26`,
+                  borderColor: `${color}66`,
+                },
+              ]}
+            >
+              {getToolIcon(keyName)}
+            </View>
+
+            {/* Title and description */}
+            <View style={styles.toolInfo}>
+              <Text style={styles.toolName}>
+                {getToolLabel(keyName)}
+                {disabled ? " (MAX 6)" : ""}
+              </Text>
+              <Text style={styles.toolDescription} numberOfLines={1}>
+                {getToolDescription(keyName)}
+              </Text>
+            </View>
+
+            {/* Pill toggle button */}
+            <TouchableOpacity
+              onPress={onToggle}
+              disabled={disabled}
+              activeOpacity={0.8}
+              style={[
+                styles.pillToggle,
+                {
+                  backgroundColor: value ? `${color}33` : "#1b2334",
+                  borderColor: value ? `${color}88` : "#2a3550",
+                  shadowColor: value ? color : "transparent",
+                  shadowOffset: { width: 0, height: 0 },
+                  shadowOpacity: value ? 0.4 : 0,
+                  shadowRadius: value ? 8 : 0,
+                },
+                disabled && { opacity: 0.5 },
+              ]}
+            >
+              <Text
+                style={[
+                  styles.pillToggleText,
+                  { color: value ? color : "#8CA2C8" },
+                ]}
+              >
+                {value ? "ON" : "OFF"}
+              </Text>
+            </TouchableOpacity>
+
+            {/* Chevron */}
+            <ChevronRightIcon size={18} color="#7F91B2" />
+          </View>
+        </View>
+      </TouchableOpacity>
+    );
+  };
+
+  const renderContent = () => (
+    <View style={styles.container}>
+      <ScrollView
+        style={styles.scrollContent}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={styles.scrollContainer}
+      >
+        {/* Show only the active tab's content */}
+        {activeTab === "dial" ? (
+          <View style={styles.section}>
+            {(() => {
+              const enabledCount = Object.values(settings.dialTools).filter(
+                (v) => v
+              ).length;
+              const isAtLimit = enabledCount >= MAX_DIAL_SLOTS;
+
+              return Object.entries(settings.dialTools).map(([key, value]) => {
+                const isDisabled = !value && isAtLimit;
+                return renderToolCard(key, value, isDisabled, () =>
+                  toggleDialTool(key as keyof DevToolsSettings["dialTools"])
+                );
+              });
+            })()}
+          </View>
+        ) : (
+          <View style={styles.section}>
+            {Object.entries(settings.floatingTools).map(([key, value]) =>
+              renderToolCard(key, value, false, () =>
+                toggleFloatingTool(
+                  key as keyof DevToolsSettings["floatingTools"]
+                )
+              )
+            )}
+          </View>
+        )}
+      </ScrollView>
+    </View>
+  );
+
+  return (
+    <JsModal
+      visible={visible}
+      onClose={onClose}
+      header={{
+        showToggleButton: false,
+        customContent: (
+          <ModalHeader>
+            <ModalHeader.Content title="" noMargin>
+              <TabSelector
+                tabs={[
+                  { key: "dial", label: "DIAL MENU" },
+                  { key: "floating", label: "FLOATING" },
+                ]}
+                activeTab={activeTab}
+                onTabChange={(tab: string) =>
+                  setActiveTab(tab as "dial" | "floating")
+                }
+              />
+            </ModalHeader.Content>
+            <ModalHeader.Actions onClose={onClose} />
+          </ModalHeader>
+        ),
+      }}
+      initialMode="bottomSheet"
+      onModeChange={handleModeChange}
+      persistenceKey={devToolsStorageKeys.settings.root()}
+      enablePersistence={false}
+      maxHeight={screenHeight - insets.top}
+      initialHeight={modalHeight}
+      initialFloatingPosition={{
+        x: (screenWidth - modalWidth) / 2,
+        y: insets.top + 20,
+      }}
+      enableGlitchEffects={true}
+    >
+      {renderContent()}
+    </JsModal>
+  );
+};
+
+// Basic default settings for the hook (when apps are not available)
+const basicDefaultSettings: DevToolsSettings = {
+  dialTools: {},
+  floatingTools: {
+    environment: false,
+  },
+};
+
+/**
+ * Convenience hook for accessing persisted dev tools settings. Subscribes to the internal
+ * event bus so all surfaces stay in sync when the modal saves new preferences.
+ */
+export const useDevToolsSettings = () => {
+  const [settings, setSettings] =
+    useState<DevToolsSettings>(basicDefaultSettings);
+
+  const loadSettings = useCallback(async () => {
+    try {
+      const savedSettings = await safeGetItem(STORAGE_KEY);
+      if (savedSettings) {
+        const parsed = JSON.parse(savedSettings) as DevToolsSettings;
+        const merged = mergeWithDefaults(basicDefaultSettings, parsed);
+        setSettings(merged);
+        return;
+      }
+      setSettings(basicDefaultSettings);
+    } catch (error) {
+      console.error("Failed to load dev tools settings:", error);
+      setSettings(basicDefaultSettings);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSettings();
+    // Subscribe to settings changes
+    const unsub = settingsBus.addListener((payload) => {
+      try {
+        if (payload) {
+          setSettings(payload);
+        }
+      } catch (err) {
+        // Listener errors are intentionally swallowed to avoid breaking subscribers
+      }
+    });
+    return () => {
+      unsub();
+    };
+  }, [loadSettings]);
+
+  // Refresh settings when component using this hook becomes visible
+  const refreshSettings = useCallback(() => {
+    loadSettings();
+  }, [loadSettings]);
+
+  return { settings, refreshSettings };
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: gameUIColors.background,
+  },
+
+  // Header styles matching React Query modal exactly
+  headerContainer: {
+    flex: 1,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 12,
+  },
+  tabNavigationContainer: {
+    flex: 1,
+    flexDirection: "row",
+    backgroundColor: gameUIColors.panel,
+    borderRadius: 6,
+    padding: 2,
+    borderWidth: 1,
+    borderColor: gameUIColors.border + "40",
+    justifyContent: "space-evenly",
+  },
+  tabButton: {
+    paddingHorizontal: 8,
+    paddingVertical: 5,
+    borderRadius: 4,
+    alignItems: "center",
+    justifyContent: "center",
+    flex: 1,
+    marginHorizontal: 1,
+  },
+  tabButtonActive: {
+    backgroundColor: gameUIColors.info + "20",
+    borderWidth: 1,
+    borderColor: gameUIColors.info + "40",
+  },
+  tabButtonInactive: {
+    backgroundColor: "transparent",
+  },
+  tabButtonText: {
+    fontSize: 12,
+    fontWeight: "600",
+    letterSpacing: 0.5,
+    fontFamily: "monospace",
+    textTransform: "uppercase",
+  },
+  tabButtonTextActive: {
+    color: gameUIColors.info,
+  },
+  tabButtonTextInactive: {
+    color: gameUIColors.muted,
+  },
+
+  // Scroll content
+  scrollContent: {
+    flex: 1,
+  },
+  scrollContainer: {
+    paddingTop: 16,
+    paddingBottom: 24,
+  },
+
+  // Sections
+  section: {
+    marginHorizontal: 16,
+    marginBottom: 24,
+  },
+  sectionHeader: {
+    flexDirection: "row",
+    alignItems: "center",
+    marginBottom: 12,
+    paddingHorizontal: 4,
+  },
+  sectionIndicator: {
+    width: 3,
+    height: 16,
+    borderRadius: 2,
+    backgroundColor: gameUIColors.primary,
+    marginRight: 8,
+    shadowColor: gameUIColors.primary,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.6,
+    shadowRadius: 4,
+  },
+  sectionTitle: {
+    flex: 1,
+    color: gameUIColors.primary,
+    fontSize: 13,
+    fontWeight: "700",
+    letterSpacing: 1.2,
+  },
+  sectionCount: {
+    color: gameUIColors.secondary,
+    fontSize: 11,
+    opacity: 0.7,
+  },
+
+  // Tool Cards - Glass + Neon Edge variant
+  glassCard: {
+    borderRadius: 999,
+    paddingVertical: 10,
+    paddingHorizontal: 14,
+    backgroundColor: "#0F172A",
+    borderWidth: 1,
+    borderColor: "#25324A",
+  },
+  glassCardInner: {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+  iconCircle: {
+    width: 28,
+    height: 28,
+    borderRadius: 14,
+    alignItems: "center",
+    justifyContent: "center",
+    borderWidth: 1,
+  },
+  toolInfo: {
+    flex: 1,
+  },
+  toolName: {
+    color: "#E6EEFF",
+    fontWeight: "800",
+    fontSize: 13,
+  },
+  toolDescription: {
+    color: "#7F91B2",
+    fontSize: 11,
+  },
+  pillToggle: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 999,
+    borderWidth: 1,
+  },
+  pillToggleText: {
+    fontWeight: "700",
+    fontSize: 11,
+  },
+  closeButton: {
+    marginLeft: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 6,
+    backgroundColor: gameUIColors.error + "1A",
+    borderWidth: 1,
+    borderColor: gameUIColors.error + "33",
+  },
+  closeButtonText: {
+    color: gameUIColors.error,
+    fontSize: 14,
+    fontWeight: "700",
+    letterSpacing: 0.5,
+  },
+});

--- a/packages/devtools-floating-menu/src/floatingMenu/DevToolsVisibilityContext.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/DevToolsVisibilityContext.tsx
@@ -1,0 +1,78 @@
+/**
+ * DevToolsVisibilityContext
+ *
+ * Tracks when DevTools UI is visible (dial menu, modals, etc.)
+ * Used by other tools (like debug borders) to hide when DevTools are active
+ */
+
+import {
+  createContext,
+  useContext,
+  ReactNode,
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+} from "react";
+
+interface DevToolsVisibilityContextValue {
+  /** True when dial menu is open */
+  isDialOpen: boolean;
+  /** True when any DevTools modal/tool is open */
+  isToolOpen: boolean;
+  /** True when either dial or any tool is open */
+  isDevToolsActive: boolean;
+  /** Set dial open state */
+  setDialOpen: (open: boolean) => void;
+  /** Set tool open state */
+  setToolOpen: (open: boolean) => void;
+}
+
+const DevToolsVisibilityContext =
+  createContext<DevToolsVisibilityContextValue | null>(null);
+
+export function DevToolsVisibilityProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [isDialOpen, setDialOpen] = useState(false);
+  const [isToolOpen, setToolOpen] = useState(false);
+
+  const isDevToolsActive = useMemo(
+    () => isDialOpen || isToolOpen,
+    [isDialOpen, isToolOpen]
+  );
+
+  const value = useMemo(
+    () => ({
+      isDialOpen,
+      isToolOpen,
+      isDevToolsActive,
+      setDialOpen,
+      setToolOpen,
+    }),
+    [isDialOpen, isToolOpen, isDevToolsActive]
+  );
+
+  return (
+    <DevToolsVisibilityContext.Provider value={value}>
+      {children}
+    </DevToolsVisibilityContext.Provider>
+  );
+}
+
+export function useDevToolsVisibility() {
+  const context = useContext(DevToolsVisibilityContext);
+  if (!context) {
+    // Return safe defaults if not within provider
+    return {
+      isDialOpen: false,
+      isToolOpen: false,
+      isDevToolsActive: false,
+      setDialOpen: () => {},
+      setToolOpen: () => {},
+    };
+  }
+  return context;
+}

--- a/packages/devtools-floating-menu/src/floatingMenu/DraggableHeader.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/DraggableHeader.tsx
@@ -1,0 +1,105 @@
+import { useRef, useMemo, memo, type ReactNode } from 'react';
+import { View, PanResponder, Animated, Dimensions, type ViewStyle, type StyleProp } from 'react-native';
+
+interface DraggableHeaderProps {
+  children: ReactNode;
+  position: Animated.ValueXY;
+  onDragStart?: () => void;
+  onDragEnd?: (finalPosition: { x: number; y: number }) => void;
+  onTap?: () => void;
+  containerBounds?: { width: number; height: number };
+  elementSize?: { width: number; height: number };
+  minPosition?: { x: number; y: number };
+  style?: StyleProp<ViewStyle>;
+  enabled?: boolean;
+  maxOverflowX?: number;
+}
+
+export const DraggableHeader = memo(function DraggableHeader({
+  children,
+  position,
+  onDragStart,
+  onDragEnd,
+  onTap,
+  containerBounds = Dimensions.get('window'),
+  elementSize = { width: 100, height: 50 },
+  minPosition = { x: 0, y: 0 },
+  style,
+  enabled = true,
+  maxOverflowX = 0,
+}: DraggableHeaderProps) {
+  const isDraggingRef = useRef(false);
+  const dragDistanceRef = useRef(0);
+  const touchOffsetRef = useRef({ x: 0, y: 0 });
+  const startPositionRef = useRef({ x: 0, y: 0 });
+
+  const panResponder = useMemo(
+    () =>
+      PanResponder.create({
+        onStartShouldSetPanResponder: () => enabled,
+        onMoveShouldSetPanResponder: (_, g) => enabled && (Math.abs(g.dx) > 1 || Math.abs(g.dy) > 1),
+        onPanResponderTerminationRequest: () => false,
+
+        onPanResponderGrant: (evt) => {
+          isDraggingRef.current = false;
+          dragDistanceRef.current = 0;
+          touchOffsetRef.current = { x: evt.nativeEvent.locationX, y: evt.nativeEvent.locationY };
+          // Capture starting position in parent coords; avoid relying on window pageX/pageY
+          position.stopAnimation(({ x, y }) => {
+            startPositionRef.current = { x, y };
+          });
+        },
+
+        onPanResponderMove: (_evt, gestureState) => {
+          const totalDistance = Math.abs(gestureState.dx) + Math.abs(gestureState.dy);
+          dragDistanceRef.current = totalDistance;
+          if (totalDistance > 5 && !isDraggingRef.current) {
+            isDraggingRef.current = true;
+            onDragStart?.();
+          }
+          // Use dx/dy relative movement so parent padding/margins don't affect dragging
+          const x = startPositionRef.current.x + gestureState.dx;
+          const y = startPositionRef.current.y + gestureState.dy;
+          position.setValue({ x, y });
+        },
+
+        onPanResponderRelease: () => {
+          const currentX = Number(JSON.stringify(position.x));
+          const currentY = Number(JSON.stringify(position.y));
+          if (dragDistanceRef.current <= 5 && !isDraggingRef.current) {
+            position.setOffset({ x: 0, y: 0 });
+            position.setValue({ x: currentX, y: currentY });
+            onTap?.();
+            return;
+          }
+          const maxX = containerBounds.width - elementSize.width + maxOverflowX;
+          const clampedX = Math.max(minPosition.x, Math.min(currentX, maxX));
+          const clampedY = Math.max(minPosition.y, Math.min(currentY, containerBounds.height - elementSize.height));
+          position.setValue({ x: clampedX, y: clampedY });
+          onDragEnd?.({ x: clampedX, y: clampedY });
+          isDraggingRef.current = false;
+        },
+
+        onPanResponderTerminate: () => {
+          isDraggingRef.current = false;
+        },
+      }),
+    [
+      enabled,
+      position,
+      onDragStart,
+      onDragEnd,
+      onTap,
+      containerBounds,
+      elementSize,
+      minPosition,
+      maxOverflowX,
+    ]
+  );
+
+  return (
+    <View style={style} {...panResponder.panHandlers}>
+      {children}
+    </View>
+  );
+});

--- a/packages/devtools-floating-menu/src/floatingMenu/FloatingDevTools.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/FloatingDevTools.tsx
@@ -1,0 +1,250 @@
+import React, { useMemo } from "react";
+import { View, StyleSheet } from "react-native";
+import { AppHostProvider } from "./AppHost";
+import { FloatingMenu, type FloatingMenuProps } from "./FloatingMenu";
+import { AppOverlay } from "./AppHost";
+import {
+  autoDiscoverPresets,
+  autoDiscoverPresetsWithCustom,
+} from "./autoDiscoverPresets";
+import type { InstalledApp } from "./types";
+import { DevToolsVisibilityProvider } from "./DevToolsVisibilityContext";
+
+/**
+ * Environment variable configuration
+ *
+ * This type is compatible with RequiredEnvVar from @react-buoy/env
+ *
+ * @example
+ * ```tsx
+ * // Simple string (just check existence)
+ * "API_URL"
+ *
+ * // Check for specific type
+ * { key: "DEBUG_MODE", expectedType: "boolean" }
+ *
+ * // Check for specific value
+ * { key: "ENVIRONMENT", expectedValue: "development" }
+ * ```
+ */
+export type EnvVarConfig =
+  | string
+  | {
+      key: string;
+      expectedValue: string;
+      description?: string;
+    }
+  | {
+      key: string;
+      expectedType:
+        | "string"
+        | "number"
+        | "boolean"
+        | "object"
+        | "array"
+        | "url";
+      description?: string;
+    };
+
+/**
+ * Storage key configuration for monitoring
+ */
+export interface StorageKeyConfig {
+  key: string;
+  expectedType?: "string" | "number" | "boolean" | "object";
+  expectedValue?: string;
+  description?: string;
+  storageType: "async" | "secure" | "mmkv";
+}
+
+/**
+ * Props for FloatingDevTools component.
+ * Apps prop is optional - if not provided, all installed dev tools are auto-discovered.
+ */
+export interface FloatingDevToolsProps extends Omit<FloatingMenuProps, "apps"> {
+  /**
+   * Optional array of custom dev tool apps or overrides.
+   * Use this ONLY for custom tools or to override built-in tool behavior.
+   * Auto-discovered tools will be merged with these apps.
+   * Apps with matching IDs will override auto-discovered ones.
+   */
+  apps?: InstalledApp[];
+
+  /**
+   * Optional environment variables to validate.
+   * Just pass the array directly - no wrapper function needed!
+   *
+   * @example
+   * ```tsx
+   * <FloatingDevTools
+   *   requiredEnvVars={[
+   *     "API_URL",  // Just check if exists
+   *     { key: "DEBUG_MODE", expectedType: "boolean" },
+   *     { key: "ENVIRONMENT", expectedValue: "development" },
+   *   ]}
+   * />
+   * ```
+   */
+  requiredEnvVars?: EnvVarConfig[];
+
+  /**
+   * Optional storage keys to monitor.
+   * Just pass the array directly!
+   *
+   * @example
+   * ```tsx
+   * <FloatingDevTools
+   *   requiredStorageKeys={[
+   *     { key: "@app/session", expectedType: "string", storageType: "async" },
+   *   ]}
+   * />
+   * ```
+   */
+  requiredStorageKeys?: StorageKeyConfig[];
+
+  /**
+   * Optional children to render within the DevToolsVisibilityProvider context.
+   * Useful for tools that need to react to DevTools visibility (like DebugBordersStandaloneOverlay).
+   *
+   * @example
+   * ```tsx
+   * <FloatingDevTools>
+   *   <DebugBordersStandaloneOverlay />
+   * </FloatingDevTools>
+   * ```
+   */
+  children?: React.ReactNode;
+}
+
+/**
+ * Unified floating development tools component with automatic preset discovery.
+ *
+ * This component combines AppHostProvider, FloatingMenu, and AppOverlay
+ * into a single component for simplified setup and better developer experience.
+ *
+ * **Zero-Config Usage:**
+ * ```tsx
+ * <FloatingDevTools environment="local" userRole="admin" />
+ * // All installed dev tools automatically appear!
+ * ```
+ *
+ * **With Validation (Super Simple!):**
+ * ```tsx
+ * <FloatingDevTools
+ *   requiredEnvVars={[
+ *     "API_URL",  // Just check existence
+ *     { key: "DEBUG_MODE", expectedType: "boolean" },
+ *   ]}
+ *   requiredStorageKeys={[
+ *     { key: "@app/session", storageType: "async" },
+ *   ]}
+ *   environment="local"
+ *   userRole="admin"
+ * />
+ * ```
+ *
+ * **With Custom Tools:**
+ * ```tsx
+ * <FloatingDevTools
+ *   apps={[myCustomTool]}
+ *   environment="local"
+ *   userRole="admin"
+ * />
+ * ```
+ *
+ * The component is absolutely positioned to float on top of your application
+ * regardless of where it's placed in the component tree.
+ *
+ * @param props - FloatingDevTools props
+ */
+export const FloatingDevTools = ({
+  apps,
+  requiredEnvVars,
+  requiredStorageKeys,
+  children,
+  ...props
+}: FloatingDevToolsProps) => {
+  // Build config overrides if requiredEnvVars or requiredStorageKeys are provided
+  const configOverrides = useMemo(() => {
+    const overrides: InstalledApp[] = [];
+
+    // If requiredEnvVars provided, create ENV tool config
+    if (requiredEnvVars && requiredEnvVars.length > 0) {
+      try {
+        const {
+          createEnvTool,
+          createEnvVarConfig,
+        } = require("@react-buoy/env");
+        // Convert simple format to the internal format
+        overrides.push(
+          createEnvTool({
+            requiredEnvVars: createEnvVarConfig(requiredEnvVars),
+          })
+        );
+      } catch (error) {
+        // Package not installed, skip
+      }
+    }
+
+    // If requiredStorageKeys provided, create Storage tool config
+    if (requiredStorageKeys && requiredStorageKeys.length > 0) {
+      try {
+        const { createStorageTool } = require("@react-buoy/storage");
+        overrides.push(createStorageTool({ requiredStorageKeys }));
+      } catch (error) {
+        // Package not installed, skip
+      }
+    }
+
+    return overrides;
+  }, [requiredEnvVars, requiredStorageKeys]);
+
+  // Combine user apps with config overrides
+  const userApps = useMemo(() => {
+    if (!apps && configOverrides.length === 0) return undefined;
+    return [...(apps || []), ...configOverrides];
+  }, [apps, configOverrides]);
+
+  // Always auto-discover, then merge with any user-provided apps or config overrides
+  // User-provided apps and config overrides take precedence (by ID)
+  const finalApps = userApps
+    ? autoDiscoverPresetsWithCustom(userApps)
+    : autoDiscoverPresets();
+
+  // Check if debug-borders is installed and auto-render the overlay
+  const DebugBordersOverlay = useMemo(() => {
+    try {
+      // @ts-ignore - Dynamic import that may not exist
+      const {
+        DebugBordersStandaloneOverlay,
+      } = require("@react-buoy/debug-borders");
+      return DebugBordersStandaloneOverlay;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  return (
+    <View style={styles.container} pointerEvents="box-none">
+      <DevToolsVisibilityProvider>
+        <AppHostProvider>
+          <FloatingMenu {...props} apps={finalApps} />
+          <AppOverlay />
+        </AppHostProvider>
+        {children}
+        {DebugBordersOverlay && <DebugBordersOverlay />}
+      </DevToolsVisibilityProvider>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    position: "absolute",
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    zIndex: 9999,
+  },
+});

--- a/packages/devtools-floating-menu/src/floatingMenu/FloatingMenu.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/FloatingMenu.tsx
@@ -1,0 +1,280 @@
+import { FC, useEffect, useMemo, useRef, useState } from "react";
+import { TouchableOpacity, StyleSheet, View, Text } from "react-native";
+import { FloatingTools, UserRole, UserStatus } from "./floatingTools";
+import type {
+  InstalledApp,
+  FloatingMenuActions,
+  FloatingMenuState,
+} from "./types";
+import { DialDevTools } from "./dial/DialDevTools";
+import type { Environment } from "@react-buoy/shared-ui";
+import { EnvironmentIndicator, gameUIColors } from "@react-buoy/shared-ui";
+import { useDevToolsSettings } from "./DevToolsSettingsModal";
+import { useAppHost } from "./AppHost";
+import { useDevToolsVisibility } from "./DevToolsVisibilityContext";
+import { toggleStateManager } from "./ToggleStateManager";
+
+/**
+ * Props for the floating developer tools launcher. Controls which apps are shown and
+ * how the menu integrates with the current host environment.
+ */
+export interface FloatingMenuProps {
+  /** Dev tool apps that can be opened from the floating menu. */
+  apps: InstalledApp[];
+  /** Shared state object passed to app renderers (e.g. icons) and the dial. */
+  state?: FloatingMenuState;
+  /** Shared action callbacks exposed to app renderers for interacting with the menu. */
+  actions?: FloatingMenuActions;
+  /** When true, hides the floating row (used when another dev app takes focus). */
+  hidden?: boolean;
+  /** Active environment metadata displayed via the environment indicator, if enabled. */
+  environment?: Environment;
+  /** Optional role that determines which user status badge is rendered. */
+  userRole?: UserRole;
+}
+
+/**
+ * FloatingMenu renders the persistent developer tools entry point. It handles visibility,
+ * integrates with the AppHost, and presents available tools as floating shortcuts and a dial.
+ */
+export const FloatingMenu: FC<FloatingMenuProps> = ({
+  apps,
+  state,
+  actions,
+  hidden,
+  environment,
+  userRole,
+}) => {
+  const [internalHidden, setInternalHidden] = useState(false);
+  const [showDial, setShowDial] = useState(false);
+  const [, forceUpdate] = useState(0); // Used to force re-render when toggle states change
+
+  const { isAnyOpen, open, registerApps } = useAppHost();
+  const wasAppOpenRef = useRef(isAnyOpen);
+  const { setDialOpen, setToolOpen } = useDevToolsVisibility();
+
+  // Subscribe to toggle state changes to update icon colors
+  useEffect(() => {
+    const unsubscribe = toggleStateManager.subscribe(() => {
+      // Force re-render when any toggle state changes
+      forceUpdate((prev) => prev + 1);
+    });
+    return unsubscribe;
+  }, []);
+
+  // Sync dial state with visibility context
+  useEffect(() => {
+    setDialOpen(showDial);
+  }, [showDial, setDialOpen]);
+
+  // Sync tool open state with visibility context
+  useEffect(() => {
+    setToolOpen(isAnyOpen);
+  }, [isAnyOpen, setToolOpen]);
+
+  // When an app is open or dial is shown, push the menu to the side instead of hiding completely
+  const shouldPushToSide = useMemo(
+    () => Boolean(showDial || isAnyOpen),
+    [showDial, isAnyOpen]
+  );
+
+  // Use external hidden prop or internal hidden state for complete hiding
+  const isCompletelyHidden = useMemo(
+    () => Boolean(hidden ?? internalHidden),
+    [hidden, internalHidden]
+  );
+
+  const { settings: devToolsSettings } = useDevToolsSettings();
+
+  // Register apps with AppHost for persistence
+  useEffect(() => {
+    if (registerApps) {
+      registerApps(apps);
+    }
+  }, [apps, registerApps]);
+
+  const mergedActions = useMemo(() => {
+    return {
+      ...(actions ?? {}),
+      closeMenu: () => setShowDial(false),
+      hideFloatingRow: () => setInternalHidden(true),
+      showFloatingRow: () => setInternalHidden(false),
+    } as FloatingMenuActions;
+  }, [actions]);
+
+  useEffect(() => {
+    if (wasAppOpenRef.current && !isAnyOpen) {
+      setInternalHidden(false);
+      setShowDial(false);
+    }
+    wasAppOpenRef.current = isAnyOpen;
+  }, [isAnyOpen]);
+
+  // Filter function for floating tools based on settings
+  const isFloatingEnabled = (id: string) => {
+    if (!devToolsSettings) return false;
+    // Default to disabled for tools without explicit preferences
+    return devToolsSettings.floatingTools[id] ?? false;
+  };
+
+  // Dial is the default/only layout
+
+  const handlePress = (app: InstalledApp) => {
+    // Call the app's onPress callback if provided
+    app?.onPress?.();
+
+    // Only open modal if not a toggle-only tool
+    if (app.launchMode !== "toggle-only") {
+      open({
+        id: app.id,
+        title: app.name,
+        component: app.component,
+        props: app.props,
+        launchMode: app.launchMode ?? "self-modal",
+        singleton: app.singleton ?? true,
+      });
+    }
+  };
+
+  return (
+    <>
+      <View
+        nativeID="floating-devtools-root"
+        pointerEvents={isCompletelyHidden ? "none" : "box-none"}
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          bottom: 0,
+          zIndex: 9999,
+          opacity: isCompletelyHidden ? 0 : 1,
+        }}
+      >
+        <FloatingTools enablePositionPersistence pushToSide={shouldPushToSide}>
+          {/* Environment badge (if enabled in settings) */}
+          {devToolsSettings?.floatingTools?.environment && environment ? (
+            <EnvironmentIndicator environment={environment} />
+          ) : null}
+
+          {/* Preferred: UserStatus as the dial launcher when a userRole is provided */}
+          {userRole ? (
+            <UserStatus userRole={userRole} onPress={() => setShowDial(true)} />
+          ) : (
+            // Fallback: small launcher icon to ensure settings are always accessible
+            <TouchableOpacity
+              accessibilityLabel="Open Dev Tools Menu"
+              onPress={() => setShowDial(true)}
+              style={styles.fab}
+            >
+              <View style={styles.menuButton}>
+                <MenuLauncherIcon size={14} />
+              </View>
+            </TouchableOpacity>
+          )}
+
+          {apps
+            .filter(
+              (a) => (a.slot ?? "both") !== "dial" && isFloatingEnabled(a.id)
+            )
+            .map((app) => (
+              <TouchableOpacity
+                key={`row-${app.id}`}
+                accessibilityLabel={app.name}
+                onPress={() => handlePress(app)}
+                style={styles.fab}
+              >
+                {typeof app.icon === "function"
+                  ? app.icon({
+                      slot: "row",
+                      size: 16,
+                      state,
+                      actions: mergedActions,
+                    })
+                  : app.icon}
+              </TouchableOpacity>
+            ))}
+        </FloatingTools>
+      </View>
+
+      {showDial && (
+        <DialDevTools
+          apps={apps}
+          state={state}
+          actions={mergedActions}
+          onClose={() => {
+            setShowDial(false);
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+const styles = StyleSheet.create({
+  fab: {
+    paddingHorizontal: 6,
+    paddingVertical: 4,
+    borderRadius: 6,
+    marginRight: 4,
+    alignItems: "center",
+    justifyContent: "center",
+    minWidth: 0,
+    minHeight: 0,
+    backgroundColor: "transparent",
+  },
+  menuButton: {
+    paddingHorizontal: 4,
+    paddingVertical: 2,
+    minWidth: 16,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  menuDots: {
+    color: "#8CA2C8",
+    fontSize: 14,
+    fontWeight: "900",
+  },
+});
+
+interface MenuLauncherIconProps {
+  /** Pixel width/height of the square icon. */
+  size?: number;
+  /** Custom color applied to each dot. */
+  color?: string;
+}
+
+/** Minimal 3x3 dot icon used when the user status badge is unavailable. */
+const MenuLauncherIcon: FC<MenuLauncherIconProps> = ({
+  size = 14,
+  color = gameUIColors.info,
+}) => {
+  const dotSize = Math.max(2, Math.floor(size / 4));
+  const gap = Math.max(1, Math.floor(size / 16));
+  const items = Array.from({ length: 9 });
+  return (
+    <View
+      style={{
+        width: size,
+        height: size,
+        flexDirection: "row",
+        flexWrap: "wrap",
+        alignContent: "center",
+        justifyContent: "center",
+      }}
+    >
+      {items.map((_, i) => (
+        <View
+          key={i}
+          style={{
+            width: dotSize,
+            height: dotSize,
+            margin: gap,
+            borderRadius: 2,
+            backgroundColor: color,
+          }}
+        />
+      ))}
+    </View>
+  );
+};

--- a/packages/devtools-floating-menu/src/floatingMenu/ToggleStateManager.ts
+++ b/packages/devtools-floating-menu/src/floatingMenu/ToggleStateManager.ts
@@ -1,0 +1,32 @@
+/**
+ * ToggleStateManager
+ *
+ * Global event emitter for toggle-only dev tools to notify when their state changes.
+ * This allows FloatingMenu to re-render and update icon colors.
+ */
+
+type Listener = () => void;
+
+class ToggleStateManager {
+  private listeners: Set<Listener> = new Set();
+
+  /**
+   * Subscribe to any toggle state change
+   */
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  /**
+   * Notify all subscribers that a toggle state changed
+   */
+  notify(): void {
+    this.listeners.forEach((listener) => listener());
+  }
+}
+
+// Singleton instance
+export const toggleStateManager = new ToggleStateManager();

--- a/packages/devtools-floating-menu/src/floatingMenu/autoDiscoverPresets.ts
+++ b/packages/devtools-floating-menu/src/floatingMenu/autoDiscoverPresets.ts
@@ -1,0 +1,200 @@
+import type { InstalledApp } from "./types";
+
+/**
+ * Automatically discovers and loads dev tool presets from installed packages.
+ *
+ * This function attempts to import presets from known dev tool packages.
+ * If a package is installed, its preset will be automatically loaded.
+ * If a package is not installed, it will be silently skipped.
+ *
+ * This enables zero-config setup - just install the packages you want
+ * and they'll automatically appear in your dev tools!
+ *
+ * @returns Array of automatically discovered preset configurations
+ *
+ * @example
+ * ```tsx
+ * import { FloatingDevTools, autoDiscoverPresets } from '@react-buoy/core';
+ *
+ * // Automatically discover and load all installed dev tool presets
+ * const autoPresets = autoDiscoverPresets();
+ *
+ * function App() {
+ *   return (
+ *     <FloatingDevTools
+ *       apps={autoPresets} // That's it! All installed tools load automatically
+ *       environment="local"
+ *       userRole="admin"
+ *     />
+ *   );
+ * }
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // Combine auto-discovery with custom tools
+ * const autoPresets = autoDiscoverPresets();
+ * const customTools = [
+ *   {
+ *     id: "my-custom-tool",
+ *     name: "CUSTOM",
+ *     // ... custom config
+ *   },
+ * ];
+ *
+ * const allTools = [...autoPresets, ...customTools];
+ *
+ * <FloatingDevTools apps={allTools} />
+ * ```
+ */
+export function autoDiscoverPresets(): InstalledApp[] {
+  const discoveredPresets: InstalledApp[] = [];
+
+  // Try to load each known preset
+  // These will only succeed if the package is actually installed
+  const presetLoaders = [
+    // ENV Tools
+    {
+      name: "@react-buoy/env",
+      loader: () => {
+        try {
+          // @ts-ignore - Dynamic import that may not exist
+          const { envToolPreset } = require("@react-buoy/env");
+          return envToolPreset;
+        } catch {
+          return null;
+        }
+      },
+    },
+    // Network Tools
+    {
+      name: "@react-buoy/network",
+      loader: () => {
+        try {
+          // @ts-ignore - Dynamic import that may not exist
+          const { networkToolPreset } = require("@react-buoy/network");
+          return networkToolPreset;
+        } catch {
+          return null;
+        }
+      },
+    },
+    // Storage Tools
+    {
+      name: "@react-buoy/storage",
+      loader: () => {
+        try {
+          // @ts-ignore - Dynamic import that may not exist
+          const { storageToolPreset } = require("@react-buoy/storage");
+          return storageToolPreset;
+        } catch {
+          return null;
+        }
+      },
+    },
+    // React Query Tools
+    {
+      name: "@react-buoy/react-query",
+      loader: () => {
+        try {
+          // @ts-ignore - Dynamic import that may not exist
+          const {
+            reactQueryToolPreset,
+            wifiTogglePreset,
+          } = require("@react-buoy/react-query");
+          return [reactQueryToolPreset, wifiTogglePreset];
+        } catch {
+          return null;
+        }
+      },
+    },
+    // Route Events
+    {
+      name: "@react-buoy/route-events",
+      loader: () => {
+        try {
+          // @ts-ignore - Dynamic import that may not exist
+          const { routeEventsToolPreset } = require("@react-buoy/route-events");
+          return routeEventsToolPreset;
+        } catch {
+          return null;
+        }
+      },
+    },
+    // Debug Borders
+    {
+      name: "@react-buoy/debug-borders",
+      loader: () => {
+        try {
+          // @ts-ignore - Dynamic import that may not exist
+          const {
+            debugBordersToolPreset,
+          } = require("@react-buoy/debug-borders");
+          return debugBordersToolPreset;
+        } catch {
+          return null;
+        }
+      },
+    },
+  ];
+
+  // Attempt to load each preset
+  for (const { name, loader } of presetLoaders) {
+    try {
+      const preset = loader();
+      if (preset) {
+        if (Array.isArray(preset)) {
+          discoveredPresets.push(...preset);
+        } else {
+          discoveredPresets.push(preset);
+        }
+      }
+    } catch (error) {
+      // Silently skip packages that aren't installed
+      // This is expected behavior - not all packages will be installed
+    }
+  }
+
+  return discoveredPresets;
+}
+
+/**
+ * Merges auto-discovered presets with custom tools, ensuring no duplicates.
+ * Custom tools take precedence over auto-discovered ones with the same ID.
+ *
+ * @param customTools - Array of custom tool configurations
+ * @returns Combined array of tools with custom tools taking precedence
+ *
+ * @example
+ * ```tsx
+ * import { FloatingDevTools, autoDiscoverPresetsWithCustom } from '@react-buoy/core';
+ * import { createEnvTool } from '@react-buoy/env';
+ *
+ * const customTools = [
+ *   // Override the env preset with custom config
+ *   createEnvTool({
+ *     requiredEnvVars: myRequiredVars,
+ *   }),
+ * ];
+ *
+ * const allTools = autoDiscoverPresetsWithCustom(customTools);
+ *
+ * <FloatingDevTools apps={allTools} />
+ * ```
+ */
+export function autoDiscoverPresetsWithCustom(
+  customTools: InstalledApp[]
+): InstalledApp[] {
+  const autoPresets = autoDiscoverPresets();
+
+  // Create a map of custom tool IDs for quick lookup
+  const customToolIds = new Set(customTools.map((tool) => tool.id));
+
+  // Filter out auto-discovered presets that have custom overrides
+  const filteredAutoPresets = autoPresets.filter(
+    (preset) => !customToolIds.has(preset.id)
+  );
+
+  // Custom tools first (higher priority), then auto-discovered
+  return [...customTools, ...filteredAutoPresets];
+}

--- a/packages/devtools-floating-menu/src/floatingMenu/dial/DialDevTools.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/dial/DialDevTools.tsx
@@ -1,0 +1,725 @@
+import { useEffect, useMemo, useRef, useState, ReactNode, FC } from "react";
+import {
+  Pressable,
+  StyleSheet,
+  View,
+  Dimensions,
+  Text,
+  Animated,
+  Easing,
+} from "react-native";
+// Icons are provided by installedApps; no direct icon imports here.
+import { DialIcon } from "./DialIcon";
+import { gameUIColors, dialColors } from "@react-buoy/shared-ui";
+import {
+  DevToolsSettingsModal,
+  type DevToolsSettings,
+  useDevToolsSettings,
+} from "../DevToolsSettingsModal";
+import type {
+  InstalledApp,
+  FloatingMenuActions,
+  FloatingMenuState,
+} from "../types";
+import { useAppHost } from "../AppHost";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+const CIRCLE_SIZE = Math.min(SCREEN_WIDTH * 0.75, 320); // Max 320px for better fit
+const BUTTON_SIZE = 80; // Fixed button size
+const MAX_DIAL_SLOTS = 6;
+
+export type IconType = {
+  id?: string; // optional; used for special behaviors like wifi toggle
+  name: string;
+  icon: ReactNode;
+  color: string;
+  onPress: () => void;
+};
+
+interface DialDevToolsProps {
+  onClose?: () => void;
+  onSettingsPress?: () => void;
+  settings?: DevToolsSettings;
+  autoOpenSettings?: boolean;
+  apps: InstalledApp[]; // required now
+  state?: FloatingMenuState;
+  actions?: FloatingMenuActions;
+}
+
+export const DialDevTools: FC<DialDevToolsProps> = ({
+  onClose,
+  onSettingsPress,
+  settings: externalSettings,
+  autoOpenSettings = false,
+  apps,
+  state,
+  actions,
+}) => {
+  const [selectedIcon, setSelectedIcon] = useState(-1);
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
+  const { settings: hookSettings, refreshSettings } = useDevToolsSettings();
+  const { open } = useAppHost();
+  // Initialize with external settings if provided, otherwise use hook settings
+  const [localSettings, setLocalSettings] = useState(
+    externalSettings || hookSettings
+  );
+
+  // Always use localSettings (which can be updated by the modal)
+  const settings = localSettings;
+
+  // Update local settings when external settings change
+  useEffect(() => {
+    if (externalSettings) {
+      setLocalSettings(externalSettings);
+    }
+  }, [externalSettings]);
+
+  // Update local settings when hook settings change (if no external settings)
+  useEffect(() => {
+    if (!externalSettings) {
+      setLocalSettings(hookSettings);
+    }
+  }, [hookSettings, externalSettings]);
+
+  // Auto-open settings modal when prop is true
+  useEffect(() => {
+    if (autoOpenSettings && !isSettingsModalOpen) {
+      setIsSettingsModalOpen(true);
+    }
+  }, [autoOpenSettings, isSettingsModalOpen]);
+
+  // React Native Animated values
+  const backdropOpacity = useRef(new Animated.Value(0)).current;
+  const dialScale = useRef(new Animated.Value(0)).current;
+  const dialRotation = useRef(new Animated.Value(0)).current;
+  const centerButtonScale = useRef(new Animated.Value(0)).current;
+  const iconsProgress = useRef(new Animated.Value(0)).current;
+  const glitchOffset = useRef(new Animated.Value(0)).current;
+  const pulseScale = useRef(new Animated.Value(1)).current;
+
+  const availableApps = useMemo(
+    () =>
+      apps.map(({ id, name, slot, description, enabledByDefault }) => ({
+        id,
+        name,
+        slot,
+        description,
+        enabledByDefault,
+      })),
+    [apps]
+  );
+
+  // Subtle animations
+  const floatingAnim = useRef(new Animated.Value(0)).current;
+  const breathingScale = useRef(new Animated.Value(1)).current;
+  const circuitOpacity = useRef(new Animated.Value(0)).current;
+
+  // Animation tracking refs
+  const glitchIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pulseAnimationRef = useRef<Animated.CompositeAnimation | null>(null);
+
+  // Map data-driven apps to dial icons, inserting empty slots for disabled items
+  const dialApps = apps.filter((a) => (a.slot ?? "both") !== "row");
+  const isDialEnabled = (id: string) => {
+    if (!settings) return false;
+    return settings.dialTools[id] ?? false;
+  };
+
+  const createEmptySlot = (slotIndex: number | string): IconType => ({
+    id: `empty-${slotIndex}`,
+    name: `empty-${slotIndex}`,
+    icon: null,
+    color: "transparent",
+    onPress: () => {},
+  });
+
+  const enabledIcons: IconType[] = [];
+  for (const app of dialApps) {
+    if (!isDialEnabled(app.id)) {
+      continue;
+    }
+    if (enabledIcons.length >= MAX_DIAL_SLOTS) {
+      break;
+    }
+
+    enabledIcons.push({
+      id: app.id,
+      name: app.name,
+      icon:
+        typeof app.icon === "function"
+          ? app.icon({ slot: "dial", size: 32, state, actions })
+          : app.icon,
+      color: app.color ?? gameUIColors.primary,
+      onPress: () => {
+        // Call the app's onPress callback if provided
+        app?.onPress?.();
+
+        // Only open modal if not a toggle-only tool
+        if (app.launchMode !== "toggle-only") {
+          open({
+            id: app.id,
+            title: app.name,
+            component: app.component,
+            props: app.props,
+            launchMode: app.launchMode ?? "self-modal",
+            singleton: app.singleton ?? true,
+          });
+        }
+
+        // Close the dial
+        onClose?.();
+      },
+    });
+  }
+
+  if (__DEV__) {
+    const totalEnabled = dialApps.filter((app) => isDialEnabled(app.id)).length;
+    if (totalEnabled > MAX_DIAL_SLOTS) {
+      // More tools enabled than can be shown - they will be hidden
+    }
+  }
+
+  const icons: IconType[] = [...enabledIcons];
+  while (icons.length < MAX_DIAL_SLOTS) {
+    icons.push(createEmptySlot(icons.length));
+  }
+
+  // Initialize animations on mount
+  useEffect(() => {
+    // Entrance animation sequence
+    Animated.timing(backdropOpacity, {
+      toValue: 1,
+      duration: 400,
+      useNativeDriver: true,
+    }).start();
+
+    Animated.spring(dialScale, {
+      toValue: 1,
+      damping: 15,
+      stiffness: 150,
+      mass: 1,
+      useNativeDriver: true,
+    }).start();
+
+    Animated.sequence([
+      Animated.timing(dialRotation, {
+        toValue: 1,
+        duration: 800,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      Animated.timing(dialRotation, {
+        toValue: 0,
+        duration: 0,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    Animated.sequence([
+      Animated.delay(300),
+      Animated.spring(centerButtonScale, {
+        toValue: 1,
+        damping: 10,
+        stiffness: 200,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    Animated.sequence([
+      Animated.delay(500),
+      Animated.timing(iconsProgress, {
+        toValue: 1,
+        duration: 600,
+        easing: Easing.out(Easing.cubic),
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // Subtle glitch effect
+    const glitchAnimation = () => {
+      Animated.sequence([
+        Animated.timing(glitchOffset, {
+          toValue: 2,
+          duration: 50,
+          useNativeDriver: true,
+        }),
+        Animated.timing(glitchOffset, {
+          toValue: -2,
+          duration: 50,
+          useNativeDriver: true,
+        }),
+        Animated.timing(glitchOffset, {
+          toValue: 0,
+          duration: 50,
+          useNativeDriver: true,
+        }),
+      ]).start();
+    };
+
+    glitchIntervalRef.current = setInterval(glitchAnimation, 3000);
+
+    // Pulse animation
+    const startPulse = () => {
+      pulseAnimationRef.current = Animated.loop(
+        Animated.sequence([
+          Animated.timing(pulseScale, {
+            toValue: 1.02,
+            duration: 1000,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+          Animated.timing(pulseScale, {
+            toValue: 0.98,
+            duration: 1000,
+            easing: Easing.inOut(Easing.ease),
+            useNativeDriver: true,
+          }),
+        ])
+      );
+      pulseAnimationRef.current.start();
+    };
+
+    startPulse();
+
+    // Subtle floating animation for the dial
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(floatingAnim, {
+          toValue: -8,
+          duration: 3000,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(floatingAnim, {
+          toValue: 0,
+          duration: 3000,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ])
+    ).start();
+
+    // Gentle breathing effect for center button
+    Animated.loop(
+      Animated.sequence([
+        Animated.timing(breathingScale, {
+          toValue: 1.05,
+          duration: 2500,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+        Animated.timing(breathingScale, {
+          toValue: 0.98,
+          duration: 2500,
+          easing: Easing.inOut(Easing.ease),
+          useNativeDriver: true,
+        }),
+      ])
+    ).start();
+
+    // Circuit traces fade in
+    Animated.timing(circuitOpacity, {
+      toValue: 1,
+      duration: 1000,
+      delay: 600,
+      useNativeDriver: true,
+    }).start();
+
+    return () => {
+      if (glitchIntervalRef.current) {
+        clearInterval(glitchIntervalRef.current);
+      }
+      if (pulseAnimationRef.current) {
+        pulseAnimationRef.current.stop();
+      }
+    };
+  }, []);
+
+  const handleClose = () => {
+    // Stop any ongoing animations first
+    if (pulseAnimationRef.current) {
+      pulseAnimationRef.current.stop();
+    }
+
+    // Exit animation sequence - reverse order of entrance
+    Animated.sequence([
+      // First animate icons back to center
+      Animated.timing(iconsProgress, {
+        toValue: 0,
+        duration: 300,
+        easing: Easing.in(Easing.cubic),
+        useNativeDriver: true,
+      }),
+      // Then scale down center button and dial
+      Animated.parallel([
+        Animated.timing(centerButtonScale, {
+          toValue: 0,
+          duration: 200,
+          easing: Easing.in(Easing.cubic),
+          useNativeDriver: true,
+        }),
+        Animated.timing(dialScale, {
+          toValue: 0,
+          duration: 250,
+          easing: Easing.in(Easing.cubic),
+          useNativeDriver: true,
+        }),
+      ]),
+      // Finally fade out backdrop
+      Animated.timing(backdropOpacity, {
+        toValue: 0,
+        duration: 200,
+        useNativeDriver: true,
+      }),
+    ]).start(() => {
+      // Use setTimeout to defer the state update to the next tick
+      // This avoids the useInsertionEffect warning
+      if (onClose) {
+        setTimeout(() => {
+          onClose();
+        }, 0);
+      }
+    });
+  };
+
+  const handleIconPress = (index: number) => {
+    setSelectedIcon(index);
+
+    // Pulse animation on selection
+    Animated.sequence([
+      Animated.spring(centerButtonScale, {
+        toValue: 0.9,
+        damping: 15,
+        stiffness: 500,
+        useNativeDriver: true,
+      }),
+      Animated.spring(centerButtonScale, {
+        toValue: 1,
+        damping: 10,
+        stiffness: 200,
+        useNativeDriver: true,
+      }),
+    ]).start();
+
+    // Trigger action
+    setTimeout(() => {
+      icons[index].onPress();
+      // Only close if it's not the WiFi toggle (by id)
+      if (icons[index].id !== "wifi") {
+        handleClose();
+      }
+    }, 50);
+  };
+
+  // Animated styles
+  const backdropAnimatedStyle = {
+    opacity: backdropOpacity,
+  };
+
+  const glitchAnimatedStyle = {
+    transform: [{ translateX: glitchOffset }],
+  };
+
+  const centerButtonAnimatedStyle = {
+    transform: [
+      {
+        scale: Animated.multiply(centerButtonScale, breathingScale),
+      },
+    ],
+  };
+
+  const pulseAnimatedStyle = {
+    transform: [{ scale: selectedIcon >= 0 ? 1 : pulseScale }],
+  };
+
+  return (
+    <View style={styles.container} nativeID="dial-devtools-root">
+      {/* Dark overlay backdrop */}
+      <Animated.View style={[styles.backdrop, backdropAnimatedStyle]}>
+        <Pressable
+          style={StyleSheet.absoluteFillObject}
+          onPress={handleClose}
+        />
+      </Animated.View>
+
+      <Animated.View
+        style={[
+          styles.parent,
+          {
+            position: "absolute",
+            left: (SCREEN_WIDTH - CIRCLE_SIZE) / 2,
+            bottom: 80,
+            transform: [
+              { translateY: floatingAnim },
+              { scale: dialScale },
+              {
+                rotate: dialRotation.interpolate({
+                  inputRange: [0, 1],
+                  outputRange: ["0deg", "360deg"],
+                }),
+              },
+            ],
+          },
+        ]}
+      >
+        {/* Cyberpunk dial background with glitch */}
+        <Animated.View style={[styles.circle, glitchAnimatedStyle]}>
+          {/* Gradient background using layered Views */}
+          <View style={styles.gradientBackground}>
+            <View style={styles.gradientLayer1} />
+            <View style={styles.gradientLayer2} />
+            <View style={styles.gradientLayer3} />
+
+            {/* Matrix grid pattern */}
+            <View style={styles.gridPattern}>
+              {Array.from({ length: 6 }).map((_, i) => (
+                <View
+                  key={i}
+                  style={[
+                    styles.gridLine,
+                    {
+                      transform: [{ rotate: `${i * 60}deg` }],
+                    },
+                  ]}
+                />
+              ))}
+            </View>
+          </View>
+
+          {/* Icon items */}
+          {icons.map((icon, i) => (
+            <DialIcon
+              selectedIcon={selectedIcon}
+              onPress={handleIconPress}
+              iconsProgress={iconsProgress}
+              icon={icon}
+              key={`${i}-${icon.name}`}
+              index={i}
+              totalIcons={icons.length}
+            />
+          ))}
+        </Animated.View>
+
+        {/* Center button */}
+        <Animated.View
+          style={[styles.buttonContainer, centerButtonAnimatedStyle]}
+        >
+          <View style={styles.buttonGradient}>
+            <View style={styles.buttonGradientLayer1} />
+            <View style={styles.buttonGradientLayer2} />
+            <View style={styles.buttonGradientLayer3} />
+
+            <View style={styles.buttonBorder}>
+              <Animated.View style={[styles.button, pulseAnimatedStyle]}>
+                <Pressable
+                  onPress={() => {
+                    if (isSettingsModalOpen) {
+                      // Close settings modal
+                      setIsSettingsModalOpen(false);
+                    } else {
+                      // Open internal settings modal
+                      setIsSettingsModalOpen(true);
+                      // Also call external handler if provided
+                      if (onSettingsPress) {
+                        onSettingsPress();
+                      }
+                    }
+                  }}
+                  style={styles.buttonPressable}
+                >
+                  {isSettingsModalOpen ? (
+                    <>
+                      <Text style={[styles.centerText, styles.closeTextTop]}>
+                        CLOSE
+                      </Text>
+                      <Text style={[styles.centerText, styles.closeTextBottom]}>
+                        SETTINGS
+                      </Text>
+                    </>
+                  ) : (
+                    <>
+                      <Text style={styles.centerText}>BUOY</Text>
+                      <Text style={styles.centerText}>DEV TOOLS</Text>
+                    </>
+                  )}
+                </Pressable>
+              </Animated.View>
+            </View>
+          </View>
+        </Animated.View>
+      </Animated.View>
+
+      {/* Settings Modal - Part of dial component for proper z-index */}
+      <DevToolsSettingsModal
+        visible={isSettingsModalOpen}
+        onClose={() => {
+          setIsSettingsModalOpen(false);
+          refreshSettings(); // Refresh from storage
+        }}
+        onSettingsChange={(newSettings) => {
+          // Immediately update local settings for instant feedback
+          setLocalSettings(newSettings);
+        }}
+        availableApps={availableApps}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 9999,
+  },
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: "rgba(0, 0, 0, 0.85)", // Darker overlay for better contrast without games
+  },
+  parent: {
+    width: CIRCLE_SIZE,
+    height: CIRCLE_SIZE,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  circle: {
+    width: CIRCLE_SIZE,
+    height: CIRCLE_SIZE,
+    borderRadius: CIRCLE_SIZE / 2,
+    position: "absolute",
+    backgroundColor: "transparent",
+    borderWidth: 1,
+    borderColor: dialColors.dialBorder,
+    shadowColor: dialColors.dialShadow,
+    shadowOffset: { width: 0, height: 0 },
+    shadowOpacity: 0.5,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  gradientBackground: {
+    width: "100%",
+    height: "100%",
+    borderRadius: CIRCLE_SIZE / 2,
+    position: "relative",
+    backgroundColor: dialColors.dialBackground,
+    overflow: "hidden",
+  },
+  gradientLayer1: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: dialColors.dialGradient1,
+    opacity: 0.6,
+    borderRadius: CIRCLE_SIZE / 2,
+  },
+  gradientLayer2: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: dialColors.dialGradient2,
+    opacity: 0.4,
+    top: "30%",
+    left: "30%",
+    borderRadius: CIRCLE_SIZE / 2,
+  },
+  gradientLayer3: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: dialColors.dialGradient3,
+    opacity: 0.3,
+    top: "50%",
+    left: "50%",
+    borderRadius: CIRCLE_SIZE / 2,
+  },
+  gridPattern: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  gridLine: {
+    position: "absolute",
+    width: CIRCLE_SIZE,
+    height: 1,
+    backgroundColor: dialColors.dialGridLine,
+  },
+  buttonContainer: {
+    zIndex: 1,
+    backgroundColor: "transparent",
+    alignItems: "center",
+    justifyContent: "center",
+    position: "absolute",
+    width: BUTTON_SIZE * 1.5,
+    height: BUTTON_SIZE * 1.5,
+    borderRadius: BUTTON_SIZE,
+  },
+  buttonGradient: {
+    width: "100%",
+    height: "100%",
+    borderRadius: BUTTON_SIZE,
+    alignItems: "center",
+    justifyContent: "center",
+    padding: 4,
+    backgroundColor: dialColors.dialBackground,
+    position: "relative",
+    overflow: "hidden",
+  },
+  buttonGradientLayer1: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: dialColors.dialGradient1,
+    opacity: 0.5,
+    borderRadius: BUTTON_SIZE,
+  },
+  buttonGradientLayer2: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: dialColors.dialGradient2,
+    opacity: 0.3,
+    top: "20%",
+    left: "20%",
+    borderRadius: BUTTON_SIZE,
+  },
+  buttonGradientLayer3: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: dialColors.dialGradient3,
+    opacity: 0.2,
+    top: "40%",
+    left: "40%",
+    borderRadius: BUTTON_SIZE,
+  },
+  buttonBorder: {
+    backgroundColor: dialColors.dialGridLine,
+    alignItems: "center",
+    justifyContent: "center",
+    width: BUTTON_SIZE * 1.2,
+    height: BUTTON_SIZE * 1.2,
+    borderRadius: BUTTON_SIZE * 0.6,
+    borderWidth: 2,
+    borderColor: dialColors.dialBorder,
+  },
+  button: {
+    width: BUTTON_SIZE,
+    height: BUTTON_SIZE,
+    borderRadius: BUTTON_SIZE / 2,
+    justifyContent: "center",
+    alignItems: "center",
+    position: "relative",
+    overflow: "hidden",
+  },
+  buttonPressable: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  centerText: {
+    color: gameUIColors.primary,
+    fontSize: 10,
+    fontWeight: "900",
+    fontFamily: "monospace",
+    letterSpacing: 1,
+    textAlign: "center",
+    textTransform: "uppercase",
+    textShadowColor: gameUIColors.info,
+    textShadowOffset: { width: 0, height: 0 },
+    textShadowRadius: 4,
+  },
+  closeTextTop: {
+    marginBottom: -2,
+  },
+  closeTextBottom: {
+    marginTop: -2,
+  },
+});

--- a/packages/devtools-floating-menu/src/floatingMenu/dial/DialIcon.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/dial/DialIcon.tsx
@@ -1,0 +1,244 @@
+import { useRef, FC } from "react";
+import {
+  StyleSheet,
+  Pressable,
+  View,
+  Text,
+  Dimensions,
+  Animated,
+} from "react-native";
+import { IconType } from "./DialDevTools";
+import { gameUIColors } from "@react-buoy/shared-ui";
+
+const { width: SCREEN_WIDTH } = Dimensions.get("window");
+const VIEW_SIZE = 60;
+const CIRCLE_SIZE = Math.min(SCREEN_WIDTH * 0.75, 320);
+const CIRCLE_RADIUS = CIRCLE_SIZE / 2;
+const START_ANGLE = (-1 * Math.PI) / 2;
+
+type Props = {
+  index: number;
+  icon: IconType;
+  iconsProgress: Animated.Value;
+  onPress: (index: number) => void;
+  selectedIcon: number;
+  totalIcons: number;
+};
+
+export const DialIcon: FC<Props> = ({
+  index,
+  icon,
+  iconsProgress,
+  onPress,
+  selectedIcon,
+  totalIcons,
+}) => {
+  const ANGLE_PER_VIEW = (2 * Math.PI) / totalIcons;
+  const angle = START_ANGLE + ANGLE_PER_VIEW * index;
+
+  // Animation values - using interpolation for better performance
+  const scale = useRef(new Animated.Value(1)).current;
+
+  // Calculate final position for this icon
+  const radius = CIRCLE_RADIUS - VIEW_SIZE / 2 - 20;
+  const finalX = radius * Math.cos(angle);
+  const finalY = radius * Math.sin(angle);
+
+  // Hover animation on press in/out
+  const handlePressIn = () => {
+    Animated.spring(scale, {
+      toValue: 0.95,
+      damping: 15,
+      stiffness: 400,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  const handlePressOut = () => {
+    Animated.spring(scale, {
+      toValue: 1,
+      damping: 15,
+      stiffness: 400,
+      useNativeDriver: true,
+    }).start();
+  };
+
+  // Create staggered progress for each icon
+  const staggerDelay = index * 0.1;
+  const maxStagger = (totalIcons - 1) * 0.1;
+
+  // Use interpolation for smooth animation that works both directions
+  const staggeredProgress = iconsProgress.interpolate({
+    inputRange: [0, staggerDelay, staggerDelay + (1 - maxStagger), 1],
+    outputRange: [0, 0, 1, 1],
+    extrapolate: "clamp",
+  });
+
+  // Spiral animation with interpolation
+  const spiralRotation = staggeredProgress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [Math.PI * 2, 0], // Spiral from 2π to 0
+  });
+
+  // Distance from center
+  const distance = staggeredProgress.interpolate({
+    inputRange: [0, 1],
+    outputRange: [0, radius],
+  });
+
+  // Calculate X and Y positions using Animated operations
+  const translateX = Animated.add(
+    Animated.multiply(
+      distance,
+      spiralRotation.interpolate({
+        inputRange: [0, Math.PI * 2],
+        outputRange: [Math.cos(angle), Math.cos(angle + Math.PI * 2)],
+      })
+    ),
+    staggeredProgress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, finalX - radius * Math.cos(angle + Math.PI * 2)],
+    })
+  );
+
+  const translateY = Animated.add(
+    Animated.multiply(
+      distance,
+      spiralRotation.interpolate({
+        inputRange: [0, Math.PI * 2],
+        outputRange: [Math.sin(angle), Math.sin(angle + Math.PI * 2)],
+      })
+    ),
+    staggeredProgress.interpolate({
+      inputRange: [0, 1],
+      outputRange: [0, finalY - radius * Math.sin(angle + Math.PI * 2)],
+    })
+  );
+
+  // Opacity animation
+  const itemOpacity = staggeredProgress.interpolate({
+    inputRange: [0, 0.3, 1],
+    outputRange: [0, 0.3, 1],
+  });
+
+  // Scale based on progress
+  const progressScale = staggeredProgress;
+
+  // Main animated style for position and appearance
+  const animatedStyle = {
+    position: "absolute" as const,
+    left: CIRCLE_RADIUS - VIEW_SIZE / 2, // Center position
+    top: CIRCLE_RADIUS - VIEW_SIZE / 2, // Center position
+    opacity: itemOpacity,
+    transform: [
+      { translateX }, // Apply translation from center
+      { translateY }, // Apply translation from center
+      { scale: Animated.multiply(scale, progressScale) },
+    ],
+  };
+
+  // Check if this is an empty spot
+  const isEmpty = icon.icon === null;
+
+  return (
+    <Animated.View style={[styles.view, animatedStyle]}>
+      {isEmpty ? (
+        // Empty spot - just show a subtle circle
+        <View style={styles.emptySpot}>
+          <View style={styles.emptyDot} />
+        </View>
+      ) : (
+        <Pressable
+          onPress={() => onPress(index)}
+          onPressIn={handlePressIn}
+          onPressOut={handlePressOut}
+          style={styles.pressable}
+        >
+          {/* Gradient background layers for depth */}
+          <View
+            style={[
+              styles.iconGradientBg,
+              {
+                backgroundColor: "rgba(0, 0, 0, 0.2)",
+              },
+            ]}
+          />
+
+          {/* Inner glow effect */}
+          <View
+            style={[
+              styles.iconInnerGlow,
+              {
+                backgroundColor: "rgba(255, 255, 255, 0.02)",
+              },
+            ]}
+          />
+
+          {/* Icon */}
+          <View style={styles.iconWrapper}>{icon.icon}</View>
+
+          {/* Label */}
+          <Text style={styles.label}>{icon.name.toUpperCase()}</Text>
+        </Pressable>
+      )}
+    </Animated.View>
+  );
+};
+
+const styles = StyleSheet.create({
+  view: {
+    width: VIEW_SIZE,
+    height: VIEW_SIZE,
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  pressable: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+    padding: 4,
+    backgroundColor: "transparent",
+  },
+  iconGradientBg: {
+    position: "absolute",
+    width: "85%",
+    height: "85%",
+    borderRadius: 12,
+    opacity: 0.3,
+  },
+  iconInnerGlow: {
+    position: "absolute",
+    width: "70%",
+    height: "70%",
+    borderRadius: 10,
+    opacity: 0.5,
+  },
+  iconWrapper: {
+    marginBottom: 4,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  label: {
+    fontSize: 8,
+    fontWeight: "900",
+    letterSpacing: 0.5,
+    fontFamily: "monospace",
+    marginTop: 2,
+    color: gameUIColors.secondary,
+  },
+  emptySpot: {
+    width: "100%",
+    height: "100%",
+    justifyContent: "center",
+    alignItems: "center",
+  },
+  emptyDot: {
+    width: 12,
+    height: 12,
+    borderRadius: 6,
+    backgroundColor: `${gameUIColors.muted}15`,
+    borderWidth: 1,
+    borderColor: `${gameUIColors.muted}50`,
+  },
+});

--- a/packages/devtools-floating-menu/src/floatingMenu/floatingTools.tsx
+++ b/packages/devtools-floating-menu/src/floatingMenu/floatingTools.tsx
@@ -1,0 +1,756 @@
+import {
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useContext,
+  createContext,
+  useCallback,
+  Children,
+  ReactNode,
+} from "react";
+import {
+  Animated,
+  Dimensions,
+  View,
+  Text,
+  TouchableOpacity,
+  type ViewStyle,
+  type TextStyle,
+} from "react-native";
+import {
+  gameUIColors,
+  getSafeAreaInsets,
+  safeGetItem,
+  safeSetItem,
+} from "@react-buoy/shared-ui";
+import { DraggableHeader } from "./DraggableHeader";
+import { useSafeAreaInsets } from "@react-buoy/shared-ui";
+
+// Using Views to render grip dots; no react-native-svg dependency
+
+// =============================
+// Local Types (self-contained)
+// =============================
+export type UserRole = "admin" | "internal" | "user";
+
+// =============================
+// Icons (self-contained)
+// =============================
+/**
+ * Grip icon component for draggable areas
+ *
+ * Renders a vertical grip pattern using View components to avoid SVG dependencies.
+ * Creates two columns of three dots each with responsive sizing.
+ *
+ * @param props - Icon configuration
+ * @param props.size - Size of the icon in pixels (default: 24)
+ * @param props.color - Color of the grip dots (default: gameUIColors.secondary + "CC")
+ * @returns JSX.Element representing the grip icon
+ */
+function GripVerticalIcon({
+  size = 24,
+  color = gameUIColors.secondary + "CC",
+}: {
+  size?: number;
+  color?: string;
+}) {
+  const containerStyle: ViewStyle = {
+    width: size,
+    height: size,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "center",
+  };
+
+  const dotSize = Math.max(2, Math.round(size / 6));
+  const columnGap = Math.max(2, Math.round(size / 12));
+  const rowGap = Math.max(2, Math.round(size / 12));
+
+  const columnStyle: ViewStyle = {
+    flexDirection: "column",
+    alignItems: "center",
+    justifyContent: "center",
+    marginHorizontal: columnGap / 2,
+  };
+
+  const dotStyle: ViewStyle = {
+    width: dotSize,
+    height: dotSize,
+    borderRadius: dotSize / 2,
+    backgroundColor: color,
+    marginVertical: rowGap / 2,
+  };
+
+  return (
+    <View style={containerStyle}>
+      <View style={columnStyle}>
+        <View style={dotStyle} />
+        <View style={dotStyle} />
+        <View style={dotStyle} />
+      </View>
+      <View style={columnStyle}>
+        <View style={dotStyle} />
+        <View style={dotStyle} />
+        <View style={dotStyle} />
+      </View>
+    </View>
+  );
+}
+
+const STORAGE_KEYS = {
+  BUBBLE_POSITION_X: "@react_buoy_bubble_position_x",
+  BUBBLE_POSITION_Y: "@react_buoy_bubble_position_y",
+} as const;
+
+// Debug logging removed for production
+
+// =============================
+// Position persistence hook
+// Extracted logic dedicated to state/IO
+// =============================
+/**
+ * Custom hook for managing floating tools position persistence
+ *
+ * Handles loading, saving, and validating the position of the floating tools bubble
+ * with automatic boundary checking and storage management.
+ *
+ * @param props - Configuration for position management
+ * @param props.animatedPosition - Animated.ValueXY for position updates
+ * @param props.bubbleWidth - Width of the bubble for boundary calculations
+ * @param props.bubbleHeight - Height of the bubble for boundary calculations
+ * @param props.enabled - Whether position persistence is enabled
+ * @param props.visibleHandleWidth - Width of visible handle when bubble is hidden
+ * @param props.listenersSuspended - Pause automatic listeners without disabling manual saves
+ *
+ * @returns Object containing position management functions
+ *
+ * @performance Uses debounced saving to avoid excessive storage operations
+ * @performance Validates positions against screen boundaries and safe areas
+ */
+function useFloatingToolsPosition({
+  animatedPosition,
+  bubbleWidth = 100,
+  bubbleHeight = 32,
+  enabled = true,
+  visibleHandleWidth = 32,
+  listenersSuspended = false,
+}: {
+  animatedPosition: Animated.ValueXY;
+  bubbleWidth?: number;
+  bubbleHeight?: number;
+  enabled?: boolean;
+  visibleHandleWidth?: number;
+  listenersSuspended?: boolean;
+}) {
+  const isInitialized = useRef(false);
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  const savePosition = useCallback(
+    async (x: number, y: number) => {
+      if (!enabled) return;
+      try {
+        await Promise.all([
+          safeSetItem(STORAGE_KEYS.BUBBLE_POSITION_X, x.toString()),
+          safeSetItem(STORAGE_KEYS.BUBBLE_POSITION_Y, y.toString()),
+        ]);
+      } catch (error) {
+        // Failed to save position - continue without persistence
+      }
+    },
+    [enabled]
+  );
+
+  const debouncedSavePosition = useCallback(
+    (x: number, y: number) => {
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = setTimeout(() => savePosition(x, y), 500);
+    },
+    [savePosition]
+  );
+
+  const loadPosition = useCallback(async (): Promise<{
+    x: number;
+    y: number;
+  } | null> => {
+    if (!enabled) return null;
+    try {
+      const [xStr, yStr] = await Promise.all([
+        safeGetItem(STORAGE_KEYS.BUBBLE_POSITION_X),
+        safeGetItem(STORAGE_KEYS.BUBBLE_POSITION_Y),
+      ]);
+      if (xStr !== null && yStr !== null) {
+        const x = parseFloat(xStr);
+        const y = parseFloat(yStr);
+        if (!Number.isNaN(x) && !Number.isNaN(y)) return { x, y };
+      }
+    } catch (error) {
+      // Failed to load position - use default
+    }
+    return null;
+  }, [enabled]);
+
+  const validatePosition = useCallback(
+    (position: { x: number; y: number }) => {
+      const { width: screenWidth, height: screenHeight } =
+        Dimensions.get("window");
+      const safeArea = getSafeAreaInsets();
+      // Prevent going off left, top, and bottom edges with safe area
+      // Allow pushing off-screen to the right so only the grab handle remains visible
+      const minX = safeArea.left; // Respect safe area left
+      const maxX = screenWidth - visibleHandleWidth; // no right padding, ensure handle is visible
+      // Add small padding below the safe area top to ensure bubble doesn't go behind notch
+      const minY = safeArea.top + 20; // Ensure bubble is below safe area
+      const maxY = screenHeight - bubbleHeight - safeArea.bottom; // Respect safe area bottom
+      const clamped = {
+        x: Math.max(minX, Math.min(position.x, maxX)),
+        y: Math.max(minY, Math.min(position.y, maxY)),
+      } as const;
+      return clamped;
+    },
+    [visibleHandleWidth, bubbleHeight]
+  );
+
+  useEffect(() => {
+    if (!enabled || isInitialized.current) return;
+    const restore = async () => {
+      const saved = await loadPosition();
+      if (saved) {
+        const validated = validatePosition(saved);
+        // Check if the saved position is out of bounds
+        const wasOutOfBounds =
+          Math.abs(saved.x - validated.x) > 5 ||
+          Math.abs(saved.y - validated.y) > 5;
+
+        if (wasOutOfBounds) {
+          // Save the corrected position
+          await savePosition(validated.x, validated.y);
+        }
+
+        animatedPosition.setValue(validated);
+      } else {
+        const { width: screenWidth, height: screenHeight } =
+          Dimensions.get("window");
+        const safeArea = getSafeAreaInsets();
+        const defaultY = Math.max(
+          safeArea.top + 20,
+          Math.min(100, screenHeight - bubbleHeight - safeArea.bottom)
+        );
+        animatedPosition.setValue({
+          x: screenWidth - bubbleWidth - 20,
+          y: defaultY, // Ensure it's within safe area bounds
+        });
+      }
+      isInitialized.current = true;
+    };
+    restore();
+  }, [
+    enabled,
+    animatedPosition,
+    loadPosition,
+    validatePosition,
+    savePosition,
+    bubbleWidth,
+    bubbleHeight,
+  ]);
+
+  useEffect(() => {
+    if (!enabled || !isInitialized.current || listenersSuspended) return;
+    const listener = animatedPosition.addListener((value) => {
+      debouncedSavePosition(value.x, value.y);
+    });
+    return () => {
+      animatedPosition.removeListener(listener);
+      if (saveTimeoutRef.current) clearTimeout(saveTimeoutRef.current);
+    };
+  }, [enabled, listenersSuspended, animatedPosition, debouncedSavePosition]);
+
+  return {
+    savePosition,
+    loadPosition,
+    isInitialized: isInitialized.current,
+  } as const;
+}
+
+// =============================
+// UI-only leaf components
+// =============================
+export function Divider() {
+  const dividerStyle: ViewStyle = {
+    width: 1,
+    height: 12,
+    backgroundColor: gameUIColors.muted + "66",
+    flexShrink: 0,
+  };
+  return <View style={dividerStyle} />;
+}
+
+function getUserStatusConfig(userRole: UserRole) {
+  switch (userRole) {
+    case "admin":
+      return {
+        label: "Admin",
+        dotColor: gameUIColors.success,
+        textColor: gameUIColors.success,
+      };
+    case "internal":
+      return {
+        label: "Internal",
+        dotColor: gameUIColors.optional,
+        textColor: gameUIColors.optional,
+      };
+    case "user":
+    default:
+      return {
+        label: "User",
+        dotColor: gameUIColors.muted,
+        textColor: gameUIColors.secondary,
+      };
+  }
+}
+
+// Context to avoid brittle prop threading and keep API composable
+const FloatingToolsContext = createContext<{ isDragging: boolean }>({
+  isDragging: false,
+});
+
+export function UserStatus({
+  userRole,
+  onPress,
+}: {
+  userRole: UserRole;
+  onPress?: () => void;
+}) {
+  const { isDragging } = useContext(FloatingToolsContext);
+  const config = getUserStatusConfig(userRole);
+  const containerStyle: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    flexShrink: 0,
+  };
+  const dotStyle: ViewStyle = {
+    width: 6,
+    height: 6,
+    borderRadius: 3,
+    backgroundColor: config.dotColor,
+    marginRight: 4,
+  };
+  const textStyle: TextStyle = {
+    fontSize: 10,
+    fontWeight: "500",
+    color: config.textColor,
+    letterSpacing: 0.3,
+  };
+  if (!onPress) {
+    return (
+      <View style={containerStyle}>
+        <View style={dotStyle} />
+        <Text style={textStyle}>{config.label}</Text>
+      </View>
+    );
+  }
+  return (
+    <TouchableOpacity
+      accessibilityRole="button"
+      onPress={onPress}
+      hitSlop={{ top: 10, bottom: 10, left: 0, right: 10 }}
+      disabled={isDragging}
+      activeOpacity={0.85}
+      style={containerStyle}
+    >
+      <View style={dotStyle} />
+      <Text style={textStyle}>{config.label}</Text>
+    </TouchableOpacity>
+  );
+}
+
+// =============================
+// Helpers
+// =============================
+function interleaveWithDividers(childrenArray: ReactNode[]): ReactNode[] {
+  const result: ReactNode[] = [];
+  childrenArray.forEach((child, index) => {
+    if (child == null || child === false) return;
+    result.push(child);
+    if (index < childrenArray.length - 1)
+      result.push(<Divider key={`divider-${index}`} />);
+  });
+  return result;
+}
+
+// =============================
+// Main Component (presentation only)
+// =============================
+export type FloatingToolsProps = {
+  enablePositionPersistence?: boolean;
+  children?: ReactNode;
+  /** When true, pushes the bubble to the side (hidden position) */
+  pushToSide?: boolean;
+};
+
+/**
+ * FloatingTools - A draggable, resizable bubble for development tools
+ *
+ * This component provides a floating bubble interface that can contain various
+ * development tools and controls. It features:
+ * - Drag and drop positioning with boundary constraints
+ * - Hide/show functionality by dragging to screen edge
+ * - Position persistence across app restarts
+ * - Safe area aware positioning
+ * - Automatic divider insertion between child components
+ *
+ * @param props - Configuration for the floating tools
+ * @param props.enablePositionPersistence - Whether to save/restore position (default: true)
+ * @param props.children - Child components to render in the bubble
+ *
+ * @returns JSX.Element representing the floating tools bubble
+ *
+ * @example
+ * ```typescript
+ * <FloatingTools enablePositionPersistence={true}>
+ *   <UserStatus userRole="admin" onPress={handleUserPress} />
+ *   <ToolButton onPress={openSettings} />
+ * </FloatingTools>
+ * ```
+ *
+ * @performance Uses native driver animations for smooth positioning
+ * @performance Implements efficient boundary checking and position validation
+ * @performance Includes debounced position saving for optimal storage performance
+ */
+export function FloatingTools({
+  enablePositionPersistence = true,
+  pushToSide = false,
+  children,
+}: FloatingToolsProps) {
+  // Animated position and drag state
+  const animatedPosition = useRef(new Animated.ValueXY()).current;
+  const saveTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [bubbleSize, setBubbleSize] = useState({ width: 100, height: 32 });
+  const [isHidden, setIsHidden] = useState(false);
+
+  // Store the position before hiding to restore when showing
+  const savedPositionRef = useRef<{ x: number; y: number } | null>(null);
+
+  // Track if the hide state was triggered by pushToSide prop vs user toggle
+  const isPushedBySideRef = useRef(false);
+
+  // Track if user has explicitly chosen to show the menu (overriding pushToSide)
+  const userWantsVisibleRef = useRef(false);
+
+  // Track previous pushToSide value to detect transitions
+  const prevPushToSideRef = useRef(pushToSide);
+
+  const safeAreaInsets = useSafeAreaInsets();
+  const { width: screenWidth, height: screenHeight } = Dimensions.get("window");
+
+  // Position persistence (state/IO extracted to hook)
+  const { savePosition } = useFloatingToolsPosition({
+    animatedPosition,
+    bubbleWidth: bubbleSize.width,
+    bubbleHeight: bubbleSize.height,
+    enabled: enablePositionPersistence,
+    visibleHandleWidth: 32,
+    listenersSuspended: isDragging,
+  });
+
+  // Effect to handle pushToSide prop changes
+  useEffect(() => {
+    // Reset user override when pushToSide becomes true (dial/modal opens)
+    // This allows auto-hide to work after user manually showed the menu
+    if (!prevPushToSideRef.current && pushToSide) {
+      userWantsVisibleRef.current = false;
+    }
+
+    prevPushToSideRef.current = pushToSide;
+
+    // Only push to side if:
+    // 1. pushToSide is true
+    // 2. Not currently hidden
+    // 3. Not being dragged
+    // 4. User hasn't manually restored (userWantsVisibleRef)
+    if (
+      pushToSide &&
+      !isHidden &&
+      !isDragging &&
+      !userWantsVisibleRef.current
+    ) {
+      // Push to side
+      const currentX = (
+        animatedPosition.x as Animated.Value & { __getValue(): number }
+      ).__getValue();
+      const currentY = (
+        animatedPosition.y as Animated.Value & { __getValue(): number }
+      ).__getValue();
+
+      // Save current position
+      savedPositionRef.current = { x: currentX, y: currentY };
+
+      const hiddenX = screenWidth - 32; // Show only the grabber
+      isPushedBySideRef.current = true;
+      setIsHidden(true);
+      Animated.timing(animatedPosition, {
+        toValue: { x: hiddenX, y: currentY },
+        duration: 200,
+        useNativeDriver: false,
+      }).start(() => {
+        savePosition(hiddenX, currentY);
+      });
+    } else if (!pushToSide && isHidden && isPushedBySideRef.current) {
+      // Restore from side when pushToSide becomes false
+      if (savedPositionRef.current) {
+        const { x: targetX, y: targetY } = savedPositionRef.current;
+        isPushedBySideRef.current = false;
+        userWantsVisibleRef.current = false; // Reset user override when tools close
+        setIsHidden(false);
+        Animated.timing(animatedPosition, {
+          toValue: { x: targetX, y: targetY },
+          duration: 200,
+          useNativeDriver: false,
+        }).start(() => {
+          savePosition(targetX, targetY);
+        });
+      }
+    }
+  }, [
+    pushToSide,
+    isHidden,
+    isDragging,
+    screenWidth,
+    animatedPosition,
+    savePosition,
+  ]);
+
+  // Check if bubble is in hidden position on load
+  useEffect(() => {
+    if (!enablePositionPersistence) return;
+
+    const checkHiddenState = () => {
+      const currentX = (
+        animatedPosition.x as Animated.Value & { __getValue(): number }
+      ).__getValue();
+      // Check if bubble is at the hidden position (showing only grabber)
+      if (currentX >= screenWidth - 32 - 5) {
+        setIsHidden(true);
+      }
+    };
+    // Delay check to ensure position is loaded
+    const timer = setTimeout(checkHiddenState, 100);
+    return () => clearTimeout(timer);
+  }, [enablePositionPersistence, animatedPosition, screenWidth]);
+
+  // Default position when persistence disabled
+  useEffect(() => {
+    if (!enablePositionPersistence) {
+      const defaultY = Math.max(
+        safeAreaInsets.top + 20,
+        Math.min(100, screenHeight - bubbleSize.height - safeAreaInsets.bottom)
+      );
+      animatedPosition.setValue({
+        x: screenWidth - bubbleSize.width - 20,
+        y: defaultY,
+      });
+    }
+  }, [
+    enablePositionPersistence,
+    animatedPosition,
+    bubbleSize.width,
+    bubbleSize.height,
+    safeAreaInsets.top,
+    safeAreaInsets.bottom,
+    screenWidth,
+    screenHeight,
+  ]);
+
+  // Cleanup timeout on component unmount
+  useEffect(() => {
+    return () => {
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+    };
+  }, []);
+
+  // Toggle hide/show function
+  const toggleHideShow = useCallback(() => {
+    const currentX = (
+      animatedPosition.x as Animated.Value & { __getValue(): number }
+    ).__getValue();
+    const currentY = (
+      animatedPosition.y as Animated.Value & { __getValue(): number }
+    ).__getValue();
+
+    if (isHidden) {
+      // Show the bubble - restore to saved position or default visible position
+      let targetX: number;
+      let targetY: number;
+
+      if (savedPositionRef.current) {
+        // Restore to the saved position
+        targetX = savedPositionRef.current.x;
+        targetY = savedPositionRef.current.y;
+      } else {
+        // Default visible position if no saved position
+        targetX = screenWidth - bubbleSize.width - 20;
+        targetY = currentY;
+      }
+
+      // User explicitly wants the menu visible (overrides pushToSide)
+      isPushedBySideRef.current = false;
+      userWantsVisibleRef.current = true;
+      setIsHidden(false);
+      Animated.timing(animatedPosition, {
+        toValue: { x: targetX, y: targetY },
+        duration: 200,
+        useNativeDriver: false,
+      }).start(() => {
+        savePosition(targetX, targetY);
+      });
+    } else {
+      // Hide the bubble - save current position before hiding
+      savedPositionRef.current = { x: currentX, y: currentY };
+
+      // User explicitly wants the menu hidden
+      userWantsVisibleRef.current = false;
+
+      const hiddenX = screenWidth - 32; // Only show the 32px grabber
+      setIsHidden(true);
+      Animated.timing(animatedPosition, {
+        toValue: { x: hiddenX, y: currentY },
+        duration: 200,
+        useNativeDriver: false,
+      }).start(() => {
+        savePosition(hiddenX, currentY);
+      });
+    }
+  }, [animatedPosition, isHidden, bubbleSize.width, savePosition, screenWidth]);
+
+  const handleDragStart = useCallback(() => {
+    setIsDragging(true);
+  }, []);
+
+  const handleDragEnd = useCallback(
+    (finalPosition: { x: number; y: number }) => {
+      let { x: currentX, y: currentY } = finalPosition;
+
+      // Check if bubble is more than 50% over the right edge
+      const bubbleMidpoint = currentX + bubbleSize.width / 2;
+      const shouldHide = bubbleMidpoint > screenWidth;
+
+      if (shouldHide) {
+        // Animate to hidden position (only grabber visible)
+        const hiddenX = screenWidth - 32; // Only show the 32px grabber
+        setIsHidden(true);
+        Animated.timing(animatedPosition, {
+          toValue: { x: hiddenX, y: currentY },
+          duration: 200,
+          useNativeDriver: false,
+        }).start(() => {
+          savePosition(hiddenX, currentY);
+        });
+      } else {
+        // Check if we're in hidden state and user is pulling it back
+        if (isHidden && currentX < screenWidth - 32 - 10) {
+          setIsHidden(false);
+        }
+
+        // Update saved position if bubble is in visible area (not hidden)
+        if (currentX < screenWidth - bubbleSize.width / 2) {
+          savedPositionRef.current = { x: currentX, y: currentY };
+        }
+
+        savePosition(currentX, currentY);
+      }
+      setIsDragging(false);
+    },
+    [animatedPosition, bubbleSize.width, isHidden, savePosition, screenWidth]
+  );
+
+  // Stable styles
+  const bubbleStyle: Animated.WithAnimatedObject<ViewStyle> = useMemo(
+    () => ({
+      position: "absolute",
+      zIndex: 1001,
+      transform: animatedPosition.getTranslateTransform(),
+    }),
+    [animatedPosition]
+  );
+
+  const containerStyle: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    backgroundColor: gameUIColors.panel,
+    borderRadius: 6,
+    borderWidth: isDragging ? 2 : 1,
+    borderColor: isDragging ? gameUIColors.info : gameUIColors.muted + "66",
+    overflow: "hidden",
+    elevation: 8,
+    shadowColor: isDragging ? gameUIColors.info + "99" : "#000",
+    shadowOffset: { width: 0, height: isDragging ? 6 : 4 },
+    shadowOpacity: isDragging ? 0.6 : 0.3,
+    shadowRadius: isDragging ? 12 : 8,
+  };
+
+  const dragHandleStyle: ViewStyle = {
+    paddingHorizontal: 6,
+    paddingVertical: 6,
+    backgroundColor: gameUIColors.muted + "1A",
+    alignItems: "center",
+    justifyContent: "center",
+    width: 32,
+    borderRightWidth: 1,
+    borderRightColor: gameUIColors.muted + "66",
+  };
+
+  const contentStyle: ViewStyle = {
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 6,
+    paddingRight: 8,
+  };
+
+  // Compose actions row with automatic dividers
+  const actions = useMemo(
+    () => interleaveWithDividers(Children.toArray(children)),
+    [children]
+  );
+
+  return (
+    <Animated.View style={bubbleStyle}>
+      <View
+        hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+        style={containerStyle}
+        onLayout={(event) => {
+          const { width, height } = event.nativeEvent.layout;
+          setBubbleSize({ width, height });
+        }}
+      >
+        <DraggableHeader
+          position={animatedPosition}
+          onDragStart={handleDragStart}
+          onDragEnd={handleDragEnd}
+          onTap={toggleHideShow}
+          containerBounds={{ width: screenWidth, height: screenHeight }}
+          elementSize={bubbleSize}
+          minPosition={{
+            x: safeAreaInsets.left,
+            y: safeAreaInsets.top + 20,
+          }}
+          style={dragHandleStyle}
+          enabled={true}
+          maxOverflowX={bubbleSize.width}
+        >
+          <GripVerticalIcon size={12} color={gameUIColors.secondary + "CC"} />
+        </DraggableHeader>
+        <FloatingToolsContext.Provider value={{ isDragging }}>
+          <View style={contentStyle}>{actions}</View>
+        </FloatingToolsContext.Provider>
+      </View>
+    </Animated.View>
+  );
+}

--- a/packages/devtools-floating-menu/src/floatingMenu/settingsBus.ts
+++ b/packages/devtools-floating-menu/src/floatingMenu/settingsBus.ts
@@ -1,0 +1,24 @@
+import type { DevToolsSettings } from './DevToolsSettingsModal';
+
+type Listener<T> = (payload: T) => void;
+
+class SimpleEventBus<T = DevToolsSettings> {
+  private listeners: Set<Listener<T>> = new Set();
+
+  emit(payload: T) {
+    this.listeners.forEach((l) => {
+      try {
+        l(payload);
+      } catch (e) {
+        console.error("Error emitting event:", e);
+      }
+    });
+  }
+
+  addListener(listener: Listener<T>) {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+}
+
+export const settingsBus = new SimpleEventBus<DevToolsSettings>();

--- a/packages/devtools-floating-menu/src/floatingMenu/types.ts
+++ b/packages/devtools-floating-menu/src/floatingMenu/types.ts
@@ -1,0 +1,64 @@
+import { ComponentType } from "react";
+
+/** Where a tool should render within the floating menu surface. */
+export type AppSlot = "row" | "dial" | "both";
+
+/** Generic, dynamic context shared with floating tools. */
+export type FloatingMenuState = Record<string, unknown>;
+/** Named callbacks that floating tools can invoke. */
+export type FloatingMenuActions = Record<string, (...args: any[]) => void>;
+
+/**
+ * Runtime details provided to tool icon renderers so they can adapt to the menu slot
+ * and size they are rendered within.
+ */
+export type FloatingMenuRenderCtx = {
+  /** Slot where the icon is being rendered (row or dial). */
+  slot: AppSlot;
+  /** Pixel size that the icon should try to fit within. */
+  size: number;
+  /** Optional shared state object supplied by the host. */
+  state?: FloatingMenuState;
+  /** Optional shared action callbacks supplied by the host. */
+  actions?: FloatingMenuActions;
+};
+
+/** Declarative description of an app that can be launched from the floating menu. */
+export interface InstalledApp {
+  /** Unique identifier used for persistence and settings. */
+  id: string;
+  /** Human readable name shown in accessibility labels and modal headers. */
+  name: string;
+  /** Brief description of what this tool does, shown in settings. */
+  description?: string;
+  /** Visual or functional icon to render in the floating menu. */
+  icon: React.ReactNode | ((ctx: FloatingMenuRenderCtx) => React.ReactNode);
+  /** Preferred layout slot; defaults to `"both"` when unspecified. */
+  slot?: AppSlot;
+  /**
+   * When true, enables the tool in the dial and/or floating row by default
+   * (before the user has configured any preferences). Has no effect once the
+   * user has explicitly toggled the tool via the settings modal, since their
+   * persisted preference always takes precedence.
+   */
+  enabledByDefault?: boolean;
+  /** Optional accent color for the tool. */
+  color?: string;
+
+  /** Plug-and-play launching component handled by the AppHost. */
+  component: ComponentType<any>;
+  /** Props to pass to the launched component (e.g. requiredEnvVars). */
+  props?: Record<string, unknown>;
+  /**
+   * How to render the component:
+   * - self-modal: component expects visible/onClose; we supply them.
+   * - host-modal: we wrap your component in a simple RN Modal.
+   * - inline: full-screen overlay, absolutely positioned.
+   * - toggle-only: no modal/overlay, only calls onPress callback.
+   */
+  launchMode?: "self-modal" | "host-modal" | "inline" | "toggle-only";
+  /** Prevent more than one instance of this app at a time. */
+  singleton?: boolean;
+  /** Optional callback invoked when the app icon is pressed. */
+  onPress?: () => void;
+}

--- a/packages/devtools-floating-menu/src/index.tsx
+++ b/packages/devtools-floating-menu/src/index.tsx
@@ -1,0 +1,38 @@
+// Export unified component - primary interface
+export { FloatingDevTools } from "./floatingMenu/FloatingDevTools";
+export type {
+  FloatingDevToolsProps,
+  EnvVarConfig,
+  StorageKeyConfig,
+} from "./floatingMenu/FloatingDevTools";
+
+// Export auto-discovery utilities
+export {
+  autoDiscoverPresets,
+  autoDiscoverPresetsWithCustom,
+} from "./floatingMenu/autoDiscoverPresets";
+
+// Export FloatingMenu and its types
+export { FloatingMenu } from "./floatingMenu/FloatingMenu";
+export * from "./floatingMenu/types";
+export {
+  DevToolsSettingsModal,
+  useDevToolsSettings,
+} from "./floatingMenu/DevToolsSettingsModal";
+export type { DevToolsSettings } from "./floatingMenu/DevToolsSettingsModal";
+
+// Export AppHost components for advanced use cases
+export {
+  AppHostProvider,
+  AppOverlay,
+  useAppHost,
+} from "./floatingMenu/AppHost";
+
+// Export DevTools visibility tracking
+export {
+  DevToolsVisibilityProvider,
+  useDevToolsVisibility,
+} from "./floatingMenu/DevToolsVisibilityContext";
+
+// Export toggle state manager
+export { toggleStateManager } from "./floatingMenu/ToggleStateManager";


### PR DESCRIPTION
## Description

This PR adds an `enabledByDefault` option to the `InstalledApp` interface, allowing library consumers to mark tools as enabled in the dial and floating row **by default** — so they appear immediately on first launch without requiring users to manually toggle each one in the settings modal.

### Problem

Currently, all tools (both built-in and custom) default to disabled in the dial and floating row. Users must open the settings modal and enable each tool individually before it becomes visible. This creates friction, especially for teams that want certain tools always available out of the box.

### Solution

A new optional `enabledByDefault?: boolean` property on `InstalledApp`:

```tsx
<FloatingDevTools
  environment="qa"
  customTools={[
    {
      name: "Auth",
      component: AuthDebugger,
      icon: "🔐",
      enabledByDefault: true,  // Appears in dial immediately
    },
  ]}
/>
```

**Key behavior:**
- When `enabledByDefault` is `true`, the tool is enabled in both the dial and floating row on first launch
- Once the user explicitly toggles a tool via the settings modal, their persisted preference (AsyncStorage) always takes precedence over `enabledByDefault`
- Respects the existing MAX_DIAL_SLOTS (6) limit via `enforceDialLimit`
- Fully backward compatible — defaults to `false` when omitted

### Changes

| File | Change |
|------|--------|
| `types.ts` | Added `enabledByDefault?: boolean` to `InstalledApp` interface |
| `DevToolsSettingsModal.tsx` | `generateDefaultSettings()` now reads `enabledByDefault` from available apps instead of hardcoding `false`; updated `DevToolsSettingsModalProps` |
| `DialDevTools.tsx` | Passes `enabledByDefault` through the `availableApps` mapping to the settings modal |
| `docs/custom-tools.md` | Documented `enabledByDefault` in the Custom Tool Schema and added a new "Default-Enabled Tools" section |
| `docs/floating-devtools.md` | Added a "Default-Enabled Tools" section with usage examples |

> **Note:** The `packages/devtools-floating-menu/` directory contains the `@react-buoy/core` source code (extracted from the published npm package v1.5.8) to show the exact implementation. The relevant diffs are in `types.ts`, `DevToolsSettingsModal.tsx`, and `DialDevTools.tsx`.

## Test Plan

- [ ] Verify a tool with `enabledByDefault: true` appears in the dial on fresh install (no persisted settings)
- [ ] Verify a tool with `enabledByDefault: false` (or omitted) remains hidden until toggled in settings
- [ ] Verify user preferences override `enabledByDefault` after toggling in settings modal
- [ ] Verify the 6-tool dial limit is still enforced when multiple tools have `enabledByDefault: true`
- [ ] Verify existing behavior is unchanged when `enabledByDefault` is not set on any tool


Made with [Cursor](https://cursor.com)